### PR TITLE
Error handling

### DIFF
--- a/src/citric/rpc/base.py
+++ b/src/citric/rpc/base.py
@@ -43,7 +43,7 @@ class BaseRPC:
             LimeSurveyStatusError: The response key from the response payload has
                 a non-null status.
         """
-        if isinstance(result, dict) and result.get("status") is not None:
+        if isinstance(result, dict) and result.get("status") not in {"OK", None}:
             raise LimeSurveyStatusError(msg=result["status"])
 
     def _check_error(self, error: Any) -> None:  # noqa: ANN101

--- a/src/citric/rpc/json.py
+++ b/src/citric/rpc/json.py
@@ -41,6 +41,7 @@ class JSONRPC(BaseRPC):
         }
 
         res = self.request_session.post(url, json=payload)
+        res.raise_for_status()
         self._check_non_empty_response(res.text)
 
         data = res.json()

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 import json
 import pytest
+from requests import HTTPError
 from requests_mock import Mocker
 from xmlrpc.client import dumps, Fault
 
@@ -96,6 +97,16 @@ def test_xml_rpc(xml_session: Session, requests_mock: Mocker):
     result = xml_session.some_method()
 
     assert result == "OK"
+
+
+def test_http_error(session: Session, requests_mock: Mocker):
+    """Test HTTP errors."""
+    requests_mock.post(
+        URL, text=make_fake_response(""), headers=JSON_HEADERS, status_code=500,
+    )
+
+    with pytest.raises(HTTPError):
+        session.some_method()
 
 
 @pytest.mark.parametrize("message", [None, "Test message"])

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -189,6 +189,17 @@ def test_status_error(session: Session, requests_mock: Mocker):
     assert str(excinfo.value) == "Status Message"
 
 
+def test_status_ok(session: Session, requests_mock: Mocker):
+    """Test result with OK status does not raise errors."""
+    requests_mock.post(
+        session.url, text=make_fake_response({"status": "OK"}), headers=JSON_HEADERS,
+    )
+
+    result = session.not_valid()
+
+    assert result["status"] == "OK"
+
+
 def test_mismatching_request_id(session: Session, requests_mock: Mocker):
     """Test result with status key raises LimeSurveyStatusError."""
     requests_mock.post(


### PR DESCRIPTION
- Do not raise exceptions when status is OK.
- Check responses for HTTP errors.

Resolves #25 
Resolves #26