### PR TITLE
Create client without explicitly creating a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,21 @@ Python.
 For the full reference, see the [RemoteControl 2 API docs][rc2api].
 
 ```python
-from citric import Client, Session
+from citric import Client
 
 LS_URL = 'http://my-ls-server.com/index.php/admin/remotecontrol'
 
-with Session(LS_URL, 'iamadmin', 'secret') as session:
-   # Create a client from an RPC session
-   client = Client(session)
+with Client(LS_URL, 'iamadmin', 'secret') as client:
+    # Get all surveys from user 'iamadmin'
+    surveys = client.list_surveys('iamadmin')
 
-   # Get all surveys from user 'iamadmin'
-   surveys = client.list_surveys('iamadmin')
+    for s in surveys:
+        print(s["surveyls_title"])
 
-   for s in surveys:
-      print(s["surveyls_title"])
-
-      # Get all questions, regardless of group
-      questions = client.list_questions(s["sid"])
-      for q in questions:
-         print(q["title"], q["question"])
+        # Get all questions, regardless of group
+        questions = client.list_questions(s["sid"])
+        for q in questions:
+            print(q["title"], q["question"])
 ```
 
 ## Development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,14 +26,11 @@ Usage
 
 .. code-block:: python
 
-   from citric import Client, Session
+   from citric import Client
 
    LS_URL = 'http://my-ls-server.com/index.php/admin/remotecontrol'
 
-   with Session(LS_URL, 'iamadmin', 'secret') as session:
-       # Create a client from an RPC session
-       client = Client(session)
-
+   with Client(LS_URL, 'iamadmin', 'secret') as client:
        # Get all surveys from user 'iamadmin'
        surveys = client.list_surveys('iamadmin')
 

--- a/src/citric/__init__.py
+++ b/src/citric/__init__.py
@@ -1,6 +1,5 @@
 """Top-level package for citric."""
 from citric.client import Client  # noqa: F401
-from citric.session import Session  # noqa: F401
 
 try:
     from importlib.metadata import version, PackageNotFoundError  # type: ignore

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -62,7 +62,7 @@ class ResponseType(str, enum.Enum):
     SHORT = "short"
 
 
-T = TypeVar("T", bound="Client")
+T = TypeVar("T", bound="_BaseClient")
 
 
 class _BaseClient:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 from requests.adapters import BaseAdapter
 
-from citric import Session
+from citric.session import Session
 
 
 class LimeSurveyMockAdapter(BaseAdapter):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ import csv
 import io
 import pytest
 
-from citric import Client, Session
+from citric import Client
 from citric.exceptions import LimeSurveyStatusError
 
 LS_URL = "http://localhost:8001/index.php/admin/remotecontrol"
@@ -17,8 +17,7 @@ LS_PW = "secret"
 @pytest.fixture(scope="session")
 def client() -> Generator[Client, None, None]:
     """RemoteControl2 API client."""
-    session = Session(LS_URL, LS_USER, LS_PW)
-    client = Client(session)
+    client = Client(LS_URL, LS_USER, LS_PW)
 
     yield client
 
@@ -28,7 +27,7 @@ def client() -> Generator[Client, None, None]:
     except LimeSurveyStatusError:
         pass
 
-    session.close()
+    client.close()
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -7,8 +7,9 @@ from citric.exceptions import (
     LimeSurveyError,
     LimeSurveyStatusError,
 )
-from citric.method import Method
 from citric import Session
+from citric.method import Method
+from citric.session import _BaseSession
 
 from .conftest import LimeSurveyMockAdapter
 
@@ -19,6 +20,18 @@ def test_method():
     m2 = m1.world
 
     assert m2("a", "b", "c") == "hello.world(a,b,c)"
+
+
+def test_base_session():
+    """Test session abstraction."""
+
+    class TestSession(_BaseSession):
+        pass
+
+    session = TestSession("mock://lime", "user", "secret")
+
+    with pytest.raises(NotImplementedError):
+        session.rpc("test", 1, 2, 3)
 
 
 def test_json_rpc(session: Session):

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -7,9 +7,8 @@ from citric.exceptions import (
     LimeSurveyError,
     LimeSurveyStatusError,
 )
-from citric import Session
 from citric.method import Method
-from citric.session import _BaseSession
+from citric.session import _BaseSession, Session
 
 from .conftest import LimeSurveyMockAdapter
 


### PR DESCRIPTION
Use inner class implementations to define the session implementation a class uses for RPC calls.

Closes #34