### PR TITLE
BREAKING CHANGE: Refactor `requests.Session` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,16 @@ and reduce the load on your server in read-intensive applications, you can use
 ```python
 import requests_cache
 
-def cached_session_factory():
-    return requests_cache.CachedSession(
-        expire_after=3600,
-        allowable_methods=["POST"],
-    )
+cached_session = requests_cache.CachedSession(
+    expire_after=3600,
+    allowable_methods=["POST"],
+)
 
 with Client(
     LS_URL,
     "iamadmin",
     "secret",
-    requests_session_factory=cached_session_factory,
+    requests_session=cached_session,
 ) as client:
 
     # Get all surveys from user "iamadmin"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -7,7 +7,6 @@ from types import TracebackType
 from typing import (
     Any,
     BinaryIO,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -36,7 +35,10 @@ class Client:
         url: LimeSurvey Remote Control endpoint.
         username: LimeSurvey user name.
         password: LimeSurvey password.
-        requests_session_factory: callable to create the requests Session
+        requests_session: A `requests.Session`_ object.
+
+    .. _requests.Session:
+        https://docs.python-requests.org/en/latest/api/#requests.Session
     """
 
     session_class = Session
@@ -46,14 +48,14 @@ class Client:
         url: str,
         username: str,
         password: str,
-        requests_session_factory: Callable[[], requests.Session] = requests.session,
+        requests_session: requests.Session = requests.session(),
     ) -> None:
         """Create a LimeSurvey Python API client."""
         self.__session = self.session_class(
             url,
             username,
             password,
-            requests_session_factory,
+            requests_session,
         )
 
     def close(self) -> None:

--- a/src/citric/session.py
+++ b/src/citric/session.py
@@ -2,7 +2,7 @@
 import logging
 import random
 from types import TracebackType
-from typing import Any, Callable, Optional, Type, TypeVar
+from typing import Any, Optional, Type, TypeVar
 
 import requests
 
@@ -24,7 +24,10 @@ class Session:
         url: LimeSurvey Remote Control endpoint.
         username: LimeSurvey user name.
         password: LimeSurvey password.
-        requests_session_factory: callable to create the requests Session
+        requests_session: A `requests.Session`_ object.
+
+    .. _requests.Session:
+        https://docs.python-requests.org/en/latest/api/#requests.Session
     """
 
     _headers = {
@@ -39,11 +42,11 @@ class Session:
         url: str,
         username: str,
         password: str,
-        requests_session_factory: Callable[[], requests.Session] = requests.session,
+        requests_session: requests.Session = requests.session(),
     ) -> None:
         """Create a LimeSurvey RPC session."""
         self.url = url
-        self._session = requests_session_factory()
+        self._session = requests_session
         self._session.headers.update(self._headers)
 
         self.__key: Optional[str] = self.get_session_key(username, password)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ class LimeSurveyMockAdapter(BaseAdapter):
         elif method in self.status_ok_methods:
             output["result"] = self.status_ok
         elif method == "__bad_id":
-            output["id"] = 1_000_000
+            output["id"] = 2
         elif method == "get_session_key":
             output["result"] = self.session_key
         elif method == "get_site_settings" and params[1] == "RPCInterface":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ class LimeSurveyMockAdapter(BaseAdapter):
         elif method in self.status_ok_methods:
             output["result"] = self.status_ok
         elif method == "__bad_id":
-            output["id"] = 2
+            output["id"] = 1_000_000
         elif method == "get_session_key":
             output["result"] = self.session_key
         elif method == "get_site_settings" and params[1] == "RPCInterface":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """pytest fixtures."""
 import json
-from typing import Any, Callable, Mapping, Optional, Tuple, Union
+from typing import Any, Mapping, Optional, Tuple, Union
 
 import pytest
 import requests
@@ -79,16 +79,11 @@ def url() -> str:
 
 
 @pytest.fixture(scope="session")
-def mock_session_factory(url: str) -> Callable[[], requests.Session]:
+def mock_session(url: str) -> requests.Session:
     """Factory for building mock sessions."""
-
-    def factory() -> requests.Session:
-        """Session factory."""
-        requests_session = requests.Session()
-        requests_session.mount(url, LimeSurveyMockAdapter())
-        return requests_session
-
-    return factory
+    requests_session = requests.Session()
+    requests_session.mount(url, LimeSurveyMockAdapter())
+    return requests_session
 
 
 @pytest.fixture(scope="session")
@@ -108,10 +103,10 @@ def session(
     url: str,
     username: str,
     password: str,
-    mock_session_factory: Callable[[], requests.Session],
+    mock_session: requests.Session,
 ):
     """Create a LimeSurvey Session fixture."""
-    session = Session(url, username, password, mock_session_factory)
+    session = Session(url, username, password, mock_session)
 
     yield session
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -1,6 +1,5 @@
 """Tests for RPC low-level calls."""
 import random
-from typing import Callable
 
 import pytest
 import requests
@@ -23,16 +22,11 @@ class RPCOffAdapter(LimeSurveyMockAdapter):
 
 
 @pytest.fixture(scope="session")
-def off_session_factory(url: str) -> Callable[[], requests.Session]:
+def off_session(url: str) -> requests.Session:
     """Session with interface turned off."""
-
-    def factory() -> requests.Session:
-        """Session factory."""
-        requests_session = requests.Session()
-        requests_session.mount(url, RPCOffAdapter())
-        return requests_session
-
-    return factory
+    requests_session = requests.Session()
+    requests_session.mount(url, RPCOffAdapter())
+    return requests_session
 
 
 def test_method():
@@ -60,10 +54,10 @@ def test_session_context(
     url: str,
     username: str,
     password: str,
-    mock_session_factory: Callable[[], requests.Session],
+    mock_session: requests.Session,
 ):
     """Test context creates a session key."""
-    with Session(url, username, password, mock_session_factory) as session:
+    with Session(url, username, password, mock_session) as session:
         assert not session.closed
         assert session.key == LimeSurveyMockAdapter.session_key
 
@@ -81,11 +75,11 @@ def test_interface_off(
     url: str,
     username: str,
     password: str,
-    off_session_factory: Callable[[], requests.Session],
+    off_session: requests.Session,
 ):
     """Test effect of JSON RPC not enabled."""
     with pytest.raises(LimeSurveyError, match="JSON RPC interface is not enabled"):
-        Session(url, username, password, off_session_factory)
+        Session(url, username, password, off_session)
 
 
 def test_empty_response(session: Session):


### PR DESCRIPTION
Require a `requests.Session` object instead of a factory