### PR TITLE
chore: do not trigger push jobs in PR branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,8 @@
 name: Tests
 on:
-- push
-- pull_request
+  pull_request: {}
+  push:
+    branches: [master]
 jobs:
   tests:
     name: ${{ matrix.session }} ${{ matrix.python-version }} / ${{ matrix.os }}


### PR DESCRIPTION
Do not trigger push jobs in PR branches