### PR TITLE
feat: Implement `get_available_site_settings` in client

### DIFF
--- a/.changes/unreleased/Added-20230314-053859.yaml
+++ b/.changes/unreleased/Added-20230314-053859.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Implement `get_available_site_settings` in client
+time: 2023-03-14T05:38:59.801934-06:00
+custom:
+  Issue: "552"

--- a/src/citric/_compat.py
+++ b/src/citric/_compat.py
@@ -6,7 +6,7 @@ import warnings
 from functools import wraps
 from typing import Any, Callable
 
-__all__ = ["DevOnlyWarning", "dev_only"]
+__all__ = ["FutureVersionWarning", "dev_only"]
 
 
 def _warning_message(next_version: str) -> tuple[str, ...]:
@@ -25,8 +25,8 @@ def _warning_message(next_version: str) -> tuple[str, ...]:
     )
 
 
-class DevOnlyWarning(UserWarning):
-    """Warning for development only functions."""
+class FutureVersionWarning(UserWarning):
+    """Warning for features not yet available in a released version of LimeSurvey."""
 
 
 def dev_only(next_version: str) -> Callable:
@@ -46,7 +46,7 @@ def dev_only(next_version: str) -> Callable:
         def wrapper(*args: Any, **kwargs: Any) -> Callable:
             warnings.warn(
                 f"Method {fn.__name__} {''.join(message)}",
-                DevOnlyWarning,
+                FutureVersionWarning,
                 stacklevel=2,
             )
             return fn(*args, **kwargs)

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -225,7 +225,7 @@ class Client:
             create_tokens,
         )
 
-    @dev_only("5.7")
+    @dev_only("6.0")
     def add_quota(
         self,
         survey_id: int,
@@ -256,7 +256,7 @@ class Client:
             ID of the newly created quota.
 
         .. versionadded:: NEXT_VERSION
-        .. limesurvey_develop:: 5.7
+        .. limesurvey_develop:: 6.0
         """
         return self.session.add_quota(
             survey_id,
@@ -487,7 +487,7 @@ class Client:
         """
         return self.__session.delete_language(survey_id, language)
 
-    @dev_only("5.7")
+    @dev_only("6.0")
     def delete_quota(self, quota_id: int) -> types.OperationStatus:
         """Delete a LimeSurvey quota.
 
@@ -498,7 +498,7 @@ class Client:
             True if the quota was deleted.
 
         .. versionadded:: NEXT_VERSION
-        .. limesurvey_develop:: 5.7
+        .. limesurvey_develop:: 6.0
         """
         return self.session.delete_quota(quota_id)
 
@@ -826,7 +826,7 @@ class Client:
         """
         return self.__session.get_question_properties(question_id, settings, language)
 
-    @dev_only("5.7")
+    @dev_only("6.0")
     def get_quota_properties(
         self,
         quota_id: int,
@@ -844,7 +844,7 @@ class Client:
             Quota properties.
 
         .. versionadded:: NEXT_VERSION
-        .. limesurvey_develop:: 5.7
+        .. limesurvey_develop:: 6.0
         """
         return self.session.get_quota_properties(quota_id, settings, language)
 
@@ -864,11 +864,15 @@ class Client:
         """
         return self.__session.get_response_ids(survey_id, token)
 
+    @dev_only("6.0")
     def get_available_site_settings(self) -> list[str]:
         """Get all available site settings.
 
         Returns:
             A list of all the available site settings.
+
+        .. versionadded:: NEXT_VERSION
+        .. limesurvey_develop:: 6.0
         """
         return self.session.get_available_site_settings()
 
@@ -1187,7 +1191,7 @@ class Client:
         """
         return self.__session.list_questions(survey_id, group_id, language)
 
-    @dev_only("5.7")
+    @dev_only("6.0")
     def list_quotas(self, survey_id: int) -> list[types.QuotaListElement]:
         """Get all quotas for a LimeSurvey survey.
 
@@ -1198,7 +1202,7 @@ class Client:
             List of quotas.
 
         .. versionadded:: NEXT_VERSION
-        .. limesurvey_develop:: 5.7
+        .. limesurvey_develop:: 6.0
         """
         return self.session.list_quotas(survey_id)
 

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -864,6 +864,14 @@ class Client:
         """
         return self.__session.get_response_ids(survey_id, token)
 
+    def get_available_site_settings(self) -> list[str]:
+        """Get all available site settings.
+
+        Returns:
+            A list of all the available site settings.
+        """
+        return self.session.get_available_site_settings()
+
     def _get_site_setting(self, setting_name: str) -> types.Result:
         """Get a global setting.
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from citric._compat import DevOnlyWarning, dev_only
+from citric._compat import FutureVersionWarning, dev_only
 
 
 @dev_only("4.0.0")
@@ -15,7 +15,7 @@ def my_function():
 def test_dev_only():
     """Test that dev_only raises a warning."""
     with pytest.warns(
-        DevOnlyWarning,
+        FutureVersionWarning,
         match="Method my_function is only supported .* 4.0.0",
     ):
         my_function()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -483,6 +483,8 @@ def test_file_upload_invalid_extension(
 @pytest.mark.integration_test
 def test_site_settings(client: citric.Client):
     """Test getting site settings."""
+    assert client.get_available_site_settings()
+
     assert client.get_available_languages() is None
     assert client.get_default_language() == "en"
     assert client.get_default_theme() == "fruity"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -480,11 +480,16 @@ def test_file_upload_invalid_extension(
         )
 
 
+@pytest.mark.dev_only
+@pytest.mark.integration_test
+def test_get_available_site_settings(client: citric.Client):
+    """Test getting available site settings."""
+    assert client.get_available_site_settings()
+
+
 @pytest.mark.integration_test
 def test_site_settings(client: citric.Client):
     """Test getting site settings."""
-    assert client.get_available_site_settings()
-
     assert client.get_available_languages() is None
     assert client.get_default_language() == "en"
     assert client.get_default_theme() == "fruity"


### PR DESCRIPTION
Related:

- Closes https://github.com/edgarrmondragon/citric/issues/553
- Blocked by https://github.com/LimeSurvey/LimeSurvey/pull/2579


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--552.org.readthedocs.build/en/552/

<!-- readthedocs-preview citric end -->