### PR TITLE
chore: Add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/* linguist-vendored
+Dockerfile linguist-vendored
+*.Dockerfile linguist-vendored


### PR DESCRIPTION
Fixes repo language stats

<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--559.org.readthedocs.build/en/559/

<!-- readthedocs-preview citric end -->