### PR TITLE
chore: Bump locked version of certifi to remove warning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -153,7 +153,7 @@ dev = ["Sphinx (==4.3.2)", "black (==22.3.0)", "build (==0.8.0)", "flake8 (==4.0
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.6.15.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -1719,7 +1719,7 @@ jupyter = ["ipykernel", "jupyterlab"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.0"
-content-hash = "832c482f4441ed095bd72b882aa4119b0e852f770020bea94f8871718a3ba68f"
+content-hash = "d023a364d44c0903a4cb41329f0ae9f4c3f22938a3fc43a87aa77b9e6d3ef7d4"
 
 [metadata.files]
 alabaster = [
@@ -1789,8 +1789,8 @@ bleach = [
     {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
+    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
 ]
 cffi = [
     {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--561.org.readthedocs.build/en/561/

<!-- readthedocs-preview citric end -->