### PR TITLE
feat: Support for Python 3.11 is no longer experimental

### DIFF
--- a/.changes/unreleased/Added-20221024-192157.yaml
+++ b/.changes/unreleased/Added-20221024-192157.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Stable support for Python 3.11
+time: 2022-10-24T19:21:57.663867-05:00
+custom:
+  Issue: "582"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,6 @@ jobs:
         - python-version: "3.11"
           os: "ubuntu-latest"
           session: "tests"
-          experimental: true
 
         - python-version: "3.10"
           os: "ubuntu-latest"


### PR DESCRIPTION
Closes #582

Blocked until https://github.com/actions/setup-python adds it.

<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--583.org.readthedocs.build/en/583/

<!-- readthedocs-preview citric end -->