### PR TITLE
chore: Bump ruff pre-commit hook to v0.0.100

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,6 @@ repos:
     -   id: poetry-check
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.99
+    rev: v0.0.100
     hooks:
       - id: ruff


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--593.org.readthedocs.build/en/593/

<!-- readthedocs-preview citric end -->