### PR TITLE
chore: Bump ruff pre-commit hook to v0.0.110

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,6 @@ repos:
     -   id: poetry-check
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.108
+    rev: v0.0.110
     hooks:
       - id: ruff


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--601.org.readthedocs.build/en/601/

<!-- readthedocs-preview citric end -->