### PR TITLE
fix!: Use keyword-only arguments for `add_participants` and `list_participants`

### DIFF
--- a/.changes/unreleased/Changed-20221118-154715.yaml
+++ b/.changes/unreleased/Changed-20221118-154715.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Use keyword-only arguments for `add_participants` and `list_participants`
+time: 2022-11-18T15:47:15.502728-06:00
+custom:
+  Issue: "607"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -199,6 +199,7 @@ class Client:
     def add_participants(
         self,
         survey_id: int,
+        *,
         participant_data: Sequence[Mapping[str, Any]],
         create_tokens: bool = True,
     ) -> list[dict[str, Any]]:
@@ -1013,6 +1014,7 @@ class Client:
     def list_participants(
         self,
         survey_id: int,
+        *,
         start: int = 0,
         limit: int = 10,
         unused: bool = False,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -332,7 +332,13 @@ def test_list_questions(client: MockClient):
 def test_add_participants(client: MockClient):
     """Test add_participants client method."""
     participants = [{"firstname": "Alice"}, {"firstname": "Bob"}]
-    assert_client_session_call(client, "add_participants", 1, participants, True)
+    assert_client_session_call(
+        client,
+        "add_participants",
+        1,
+        participant_data=participants,
+        create_tokens=True,
+    )
 
 
 def test_delete_participants(client: MockClient):
@@ -356,7 +362,16 @@ def test_participant_properties(client: MockClient):
 
 def test_list_participants(client: MockClient):
     """Test get_participant_properties client method."""
-    assert_client_session_call(client, "list_participants", 1, 0, 10, False, False, {})
+    assert_client_session_call(
+        client,
+        "list_participants",
+        1,
+        start=0,
+        limit=10,
+        unused=False,
+        attributes=False,
+        conditions={},
+    )
 
 
 def test_get_default_theme(client: MockClient):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -260,7 +260,11 @@ def test_participants(client: citric.Client, survey_id: int):
     ]
 
     # Add participants
-    added = client.add_participants(survey_id, data, create_tokens=False)
+    added = client.add_participants(
+        survey_id,
+        participant_data=data,
+        create_tokens=False,
+    )
     for p, d in zip(added, data):
         assert p["email"] == d["email"]
         assert p["firstname"] == d["firstname"]


### PR DESCRIPTION
Closes https://github.com/edgarrmondragon/citric/issues/607


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--608.org.readthedocs.build/en/608/

<!-- readthedocs-preview citric end -->