### PR TITLE
chore: Bump ruff pre-commit hook to v0.0.133

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,6 @@ repos:
     -   id: poetry-check
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.132
+    rev: v0.0.133
     hooks:
       - id: ruff


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--614.org.readthedocs.build/en/614/

<!-- readthedocs-preview citric end -->