### PR TITLE
chore(deps): Remove upper bound on `importlib-metadata`

### DIFF
--- a/.changes/unreleased/Changed-20221215-004844.yaml
+++ b/.changes/unreleased/Changed-20221215-004844.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Remove upper bound constrain on `importlib-metadata`
+time: 2022-12-15T00:48:44.276712-06:00
+custom:
+  Issue: "642"

--- a/poetry.lock
+++ b/poetry.lock
@@ -311,14 +311,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "4.13.0"
+version = "5.1.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-4.13.0-py3-none-any.whl", hash = "sha256:8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116"},
-    {file = "importlib_metadata-4.13.0.tar.gz", hash = "sha256:dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d"},
+    {file = "importlib_metadata-5.1.0-py3-none-any.whl", hash = "sha256:d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313"},
+    {file = "importlib_metadata-5.1.0.tar.gz", hash = "sha256:d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b"},
 ]
 
 [package.dependencies]
@@ -1314,4 +1314,4 @@ docs = ["furo", "myst-parser", "sphinx", "sphinx-autoapi", "sphinx-autobuild", "
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.0"
-content-hash = "77f9cd8f8c83197ea4e4be486c08b840d3fa99512de569a3068c2a1dde299a3b"
+content-hash = "718205126e91a6a865bb2d8d65c6532b1b7fed1cf0ccb055271f57ed0c59dbea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ version = "0.4.1"
 "Issue Tracker" = "https://github.com/edgarrmondragon/citric/issues"
 
 [tool.poetry.dependencies]
-importlib_metadata = {version = ">=1.6,<5.0", python = "<3.8"}
+importlib_metadata = {version = ">=1.6", python = "<3.8"}
 python = "^3.7.0"
 requests = "^2.23.0"
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--642.org.readthedocs.build/en/642/

<!-- readthedocs-preview citric end -->