### PR TITLE
test: Add `--only-binary` flag to Nox tests session

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,9 +190,6 @@ jobs:
         docker ps -a
 
     - name: Run Nox
-      env:
-        PIP_ONLY_BINARY: ":all:"
-        PIP_NO_BINARY: ${{ (matrix.python-version == '3.12' || matrix.python-version == 'pypy3.9') && 'coverage' }}
       run: |
         nox
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -77,10 +77,12 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Execute pytest tests and compute coverage."""
     deps = ["coverage[toml]", "pytest"]
+    env = {"PIP_ONLY_BINARY": ":all:"}
+
     if "GITHUB_ACTIONS" in os.environ:
         deps.append("pytest-github-actions-annotate-failures")
 
-    session.install(".")
+    session.install(".", env=env)
     session.install(*deps)
     args = session.posargs or ["-m", "not integration_test"]
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--654.org.readthedocs.build/en/654/

<!-- readthedocs-preview citric end -->