### PR TITLE
fix: Use a correct UTC datetime as the default end value in `export_timeline`

### DIFF
--- a/.changes/unreleased/Fixed-20221229-091958.yaml
+++ b/.changes/unreleased/Fixed-20221229-091958.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Use a correct UTC datetime as the default end value in `export_timeline`
+time: 2022-12-29T09:19:58.050872-06:00
+custom:
+  Issue: "659"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -675,7 +675,9 @@ class Client:
             survey_id,
             enums.TimelineAggregationPeriod(period),
             start.isoformat(),
-            end.isoformat() if end else datetime.datetime.utcnow().isoformat(),
+            end.isoformat()
+            if end
+            else datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
         )
 
     def get_group_properties(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -349,7 +349,11 @@ def test_delete_participants(client: MockClient):
 
 def test_export_timeline(client: MockClient):
     """Test export_timeline client method."""
-    assert client.export_timeline(1, "hour", datetime.datetime(2020, 1, 1)) == {
+    assert client.export_timeline(
+        1,
+        "hour",
+        datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc),
+    ) == {
         "2022-01-01": 4,
         "2022-01-02": 2,
     }


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--659.org.readthedocs.build/en/659/

<!-- readthedocs-preview citric end -->