### PR TITLE
test: Use `contextlib.suppress` to ignore errors during tear down

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import csv
 import io
 import os
@@ -45,11 +46,9 @@ def client(url: str) -> Generator[citric.Client, None, None]:
 
     yield client
 
-    try:
+    with contextlib.suppress(LimeSurveyStatusError):
         for survey in client.list_surveys():
             client.delete_survey(survey["sid"])
-    except LimeSurveyStatusError:
-        pass
 
     client.close()
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--663.org.readthedocs.build/en/663/

<!-- readthedocs-preview citric end -->