### PR TITLE
chore: Enable `flake8-commas` checks in Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ select = [
   "PLR", # Pylint
   "PLW", # Pylint
   "PIE", # flake8-pie
+  "COM", # flake8-commas
   "RUF", # Ruff-specific rules
 ]
 src = ["src", "tests"]


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--678.org.readthedocs.build/en/678/

<!-- readthedocs-preview citric end -->