### PR TITLE
refactor: Use `pathlib.Path` where possible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 project = "citric"
 author = "Edgar Ramírez Mondragón"
@@ -23,7 +23,7 @@ autodoc_typehints_description_target = "documented"
 autoapi_type = "python"
 autoapi_root = "_api"
 autoapi_dirs = [
-    os.path.abspath("../src"),
+    Path("../src").resolve(),
 ]
 autoapi_options = [
     "members",

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -283,7 +283,7 @@ class Client:
         response_data: Mapping[str, Any],
         question_mapping: dict[str, dict[str, Any]],
     ) -> dict[str, Any]:
-        """Converts response keys to LimeSurvey's internal representation.
+        """Convert response keys to LimeSurvey's internal representation.
 
         Args:
             response_data: The response mapping.
@@ -568,7 +568,7 @@ class Client:
         Returns:
             Bytes length written to file.
         """
-        with open(filename, "wb") as f:
+        with Path(filename).open("wb") as f:
             return f.write(
                 self.export_responses(
                     survey_id,
@@ -642,7 +642,7 @@ class Client:
         Returns:
             Bytes length written to file.
         """
-        with open(filename, "wb") as f:
+        with Path(filename).open("wb") as f:
             return f.write(
                 self.export_statistics(
                     survey_id,
@@ -924,7 +924,7 @@ class Client:
         for file in uploaded_files:
             filepath = dirpath / file.meta.filename
             filepaths.append(filepath)
-            with open(filepath, "wb") as f:
+            with Path(filepath).open("wb") as f:
                 f.write(file.content.read())
 
         return filepaths
@@ -1243,5 +1243,5 @@ class Client:
         if filename is None:
             filename = path.name
 
-        with open(path, "rb") as file:
+        with Path(path).open("rb") as file:
             return self.upload_file_object(survey_id, field, filename, file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ class LimeSurveyMockAdapter(BaseAdapter):
         cert: Any | None = None,
         proxies: Mapping[str, str] | None = None,
     ):
-        """Sends a mocked request."""
+        """Send a mocked request."""
         request_data = json.loads(request.body or "{}")
 
         response = requests.Response()
@@ -76,18 +76,18 @@ class LimeSurveyMockAdapter(BaseAdapter):
         return response
 
     def close(self):
-        """Cleans up adapter specific items."""
+        """Clean up adapter specific items."""
 
 
 @pytest.fixture(scope="session")
 def url() -> str:
-    """Dummy LimeSurvey RemoteControl URL."""
+    """Get a dummy LimeSurvey RemoteControl URL."""
     return "lime://example.com"
 
 
 @pytest.fixture(scope="session")
 def mock_session(url: str) -> requests.Session:
-    """Factory for building mock sessions."""
+    """Create a mock requests session."""
     requests_session = requests.Session()
     requests_session.mount(url, LimeSurveyMockAdapter())
     return requests_session
@@ -95,13 +95,13 @@ def mock_session(url: str) -> requests.Session:
 
 @pytest.fixture(scope="session")
 def username() -> str:
-    """Dummy LimeSurvey username."""
+    """Get a dummy LimeSurvey username."""
     return "limeuser"
 
 
 @pytest.fixture(scope="session")
 def password() -> str:
-    """Dummy LimeSurvey password."""
+    """Get a dummy LimeSurvey password."""
     return "limesecret"
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,7 +43,7 @@ class MockSession(Session):
         """Create a mock session."""
 
     def rpc(self, method: str, *params: Any) -> dict[str, Any]:
-        """A mock RPC call."""
+        """Process a mock RPC call."""
         return {"method": method, "params": [*params]}
 
     def import_group(
@@ -403,10 +403,10 @@ def test_import_group(client: MockClient, tmp_path: Path):
 
     filepath = Path(tmp_path) / "group.lsq"
 
-    with open(filepath, "wb") as f:
+    with Path(filepath).open("wb") as f:
         f.write(random_bytes)
 
-    with open(filepath, "rb") as f:
+    with Path(filepath).open("rb") as f:
         assert client.import_group(f, 100, ImportGroupType.LSG) == random_bytes
 
 
@@ -416,10 +416,10 @@ def test_import_question(client: MockClient, tmp_path: Path):
 
     filepath = Path(tmp_path) / "question.lsq"
 
-    with open(filepath, "wb") as f:
+    with Path(filepath).open("wb") as f:
         f.write(random_bytes)
 
-    with open(filepath, "rb") as f:
+    with Path(filepath).open("rb") as f:
         assert client.import_question(f, 100, 1) == random_bytes
 
 
@@ -429,10 +429,10 @@ def test_import_survey(client: MockClient, tmp_path: Path):
 
     filepath = Path(tmp_path) / "survey.lss"
 
-    with open(filepath, "wb") as f:
+    with Path(filepath).open("wb") as f:
         f.write(random_bytes)
 
-    with open(filepath, "rb") as f:
+    with Path(filepath).open("rb") as f:
         assert client.import_survey(f) == {
             "content": random_bytes,
             "type": ImportSurveyType.LSS,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -57,7 +57,7 @@ def client(url: str) -> Generator[citric.Client, None, None]:
 @pytest.fixture
 def survey_id(client: citric.Client) -> Generator[int, None, None]:
     """Import a survey from a file and return its ID."""
-    with open("./examples/survey.lss", "rb") as f:
+    with Path("./examples/survey.lss").open("rb") as f:
         survey_id = client.import_survey(f, survey_id=98765)
 
     yield survey_id
@@ -149,7 +149,7 @@ def test_survey(client: citric.Client):
 def test_group(client: citric.Client, survey_id: int):
     """Test group methods."""
     # Import a group
-    with open("./examples/group.lsg", "rb") as f:
+    with Path("./examples/group.lsg").open("rb") as f:
         group_id = client.import_group(f, survey_id)
 
     # Get group properties
@@ -181,7 +181,7 @@ def test_question(client: citric.Client, survey_id: int):
     group_id = client.add_group(survey_id, "Test Group")
 
     # Import a question from a lsq file
-    with open("./examples/free_text.lsq", "rb") as f:
+    with Path("./examples/free_text.lsq").open("rb") as f:
         question_id = client.import_question(f, survey_id, group_id)
 
     # Get question properties


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--683.org.readthedocs.build/en/683/

<!-- readthedocs-preview citric end -->