### PR TITLE
chore: Drop pre-commit hook for poetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,11 +60,6 @@ repos:
   - id: pycln
     args: [--all]
 
-- repo: https://github.com/python-poetry/poetry
-  rev: 1.3.2
-  hooks:
-  - id: poetry-check
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.0.235
   hooks:


### PR DESCRIPTION
Not all that useful and `pre-commit autoupdate` keeps reverting it to an older tag :(


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--689.org.readthedocs.build/en/689/

<!-- readthedocs-preview citric end -->