### PR TITLE
refactor: Move `RPCInterfaceNotEnabledError` to `citric.exceptions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ select = [
   "B0", # flake8-bugbear
   "A0", # flake8-builtins
   "C4", # flake8-comprehensions
+  "DTZ", # flake8-datetimez
   "T1", # flake8-debugger
   "EM", # flake8-errmsg
   "ICN", # flake8-import-conventions
@@ -138,7 +139,7 @@ select = [
   "SIM", # flake8-simplify
   "TID", # flake8-tidy-imports
   "ARG", # flake8-unused-arguments
-  "DTZ", # flake8-datetimez
+  "PTH", # flake8-use-pathlib
   "ERA", # eradicate
   "PD", # pandas-vet
   "PGH", # pygrep-hooks
@@ -152,7 +153,6 @@ select = [
   "EXE", # flake8-executable
   "TCH", # flake8-type-checking
   "TRY", # tryceratops
-  "PTH", # flake8-use-pathlib
   "RUF", # Ruff-specific rules
 ]
 src = ["src", "tests"]

--- a/src/citric/exceptions.py
+++ b/src/citric/exceptions.py
@@ -25,3 +25,11 @@ class LimeSurveyStatusError(LimeSurveyError):
 
 class LimeSurveyApiError(LimeSurveyError):
     """Exception raised when LimeSurvey responds with a non-null error."""
+
+
+class RPCInterfaceNotEnabledError(LimeSurveyError):
+    """RPC interface not enabled on LimeSurvey."""
+
+    def __init__(self) -> None:
+        """Create a new exception."""
+        super().__init__("RPC interface not enabled")

--- a/src/citric/session.py
+++ b/src/citric/session.py
@@ -10,9 +10,9 @@ import requests
 
 from citric.exceptions import (
     LimeSurveyApiError,
-    LimeSurveyError,
     LimeSurveyStatusError,
     ResponseMismatchError,
+    RPCInterfaceNotEnabledError,
 )
 from citric.method import Method
 
@@ -23,14 +23,6 @@ if TYPE_CHECKING:
 GET_SESSION_KEY = "get_session_key"
 _T = TypeVar("_T", bound="Session")
 logger = logging.getLogger(__name__)
-
-
-class RPCInterfaceNotEnabledError(LimeSurveyError):
-    """RPC interface not enabled on LimeSurvey."""
-
-    def __init__(self) -> None:
-        """Create a new exception."""
-        super().__init__("RPC interface not enabled")
 
 
 class Session:
@@ -157,7 +149,7 @@ class Session:
         res.raise_for_status()
 
         if res.text == "":
-            raise RPCInterfaceNotEnabledError()
+            raise RPCInterfaceNotEnabledError
 
         data = res.json()
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -10,9 +10,9 @@ import requests
 
 from citric.exceptions import (
     LimeSurveyApiError,
-    LimeSurveyError,
     LimeSurveyStatusError,
     ResponseMismatchError,
+    RPCInterfaceNotEnabledError,
 )
 from citric.method import Method
 from citric.session import Session
@@ -94,7 +94,7 @@ def test_session_context(
 
 def test_empty_response(session: Session):
     """Test empty response."""
-    with pytest.raises(LimeSurveyError, match="RPC interface not enabled"):
+    with pytest.raises(RPCInterfaceNotEnabledError, match="RPC interface not enabled"):
         session.__disabled()
 
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--698.org.readthedocs.build/en/698/

<!-- readthedocs-preview citric end -->