### PR TITLE
ci: Mark MySQL integration test as experimental so coverage can run even when they fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,7 @@ jobs:
           os: "ubuntu-22.04"
           session: "integration"
           image_tag: "5-apache"
+          experimental: true
           database: mysql
 
         - python-version: "3.10"


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--749.org.readthedocs.build/en/749/

<!-- readthedocs-preview citric end -->