### PR TITLE
chore: All tests against upstream `master` now pass

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,6 +202,7 @@ def test_question(client: citric.Client, survey_id: int):
 
 
 @pytest.mark.integration_test
+@pytest.mark.version("master")
 def test_quota(client: citric.Client, survey_id: int):
     """Test quota methods."""
     with pytest.raises(LimeSurveyStatusError, match="No quotas found"):
@@ -487,6 +488,7 @@ def test_file_upload_invalid_extension(
 
 
 @pytest.mark.integration_test
+@pytest.mark.version("master")
 def test_get_available_site_settings(client: citric.Client):
     """Test getting available site settings."""
     assert client.get_available_site_settings()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,7 +202,6 @@ def test_question(client: citric.Client, survey_id: int):
 
 
 @pytest.mark.integration_test
-@pytest.mark.version("develop")
 def test_quota(client: citric.Client, survey_id: int):
     """Test quota methods."""
     with pytest.raises(LimeSurveyStatusError, match="No quotas found"):
@@ -488,7 +487,6 @@ def test_file_upload_invalid_extension(
 
 
 @pytest.mark.integration_test
-@pytest.mark.version("develop")
 def test_get_available_site_settings(client: citric.Client):
     """Test getting available site settings."""
     assert client.get_available_site_settings()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,6 +202,7 @@ def test_question(client: citric.Client, survey_id: int):
 
 
 @pytest.mark.integration_test
+@pytest.mark.version("develop")
 @pytest.mark.version("master")
 def test_quota(client: citric.Client, survey_id: int):
     """Test quota methods."""
@@ -488,6 +489,7 @@ def test_file_upload_invalid_extension(
 
 
 @pytest.mark.integration_test
+@pytest.mark.version("develop")
 @pytest.mark.version("master")
 def test_get_available_site_settings(client: citric.Client):
     """Test getting available site settings."""


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--802.org.readthedocs.build/en/802/

<!-- readthedocs-preview citric end -->