### PR TITLE
docs: Use Python 3.11 and Ubuntu 22.04 in RTD build config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
    configuration: docs/conf.py


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--844.org.readthedocs.build/en/844/

<!-- readthedocs-preview citric end -->