### PR TITLE
chore: Do not run test on 3.12 by default locally, when running all Nox sessions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
       LS_PASSWORD: "notverysecret"
       LS_PORT: "8080"
       NOXSESSION: "${{ matrix.session }}"
-      NOXPYTHON: "${{ matrix.python-version }}"
       NOXFORCEPYTHON: "${{ matrix.python-version }}"
     strategy:
       fail-fast: false

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ TEST_DEPS = ["coverage[toml]", "faker", "pytest"]
 
 package = "citric"
 
-python_versions = ["3.12", "3.11", "3.10", "3.9", "3.8", "3.7"]
+python_versions = ["3.11", "3.10", "3.9", "3.8", "3.7"]
 pypy_versions = ["pypy3.7", "pypy3.8", "pypy3.9"]
 all_python_versions = python_versions + pypy_versions
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--882.org.readthedocs.build/en/882/

<!-- readthedocs-preview citric end -->