### PR TITLE
docs: Restore duplicate documentation for `Client` class so links are not broken

### DIFF
--- a/.changes/unreleased/Documentation-20230621-181718.yaml
+++ b/.changes/unreleased/Documentation-20230621-181718.yaml
@@ -1,5 +1,0 @@
-kind: Documentation
-body: Deduplicate `citric.Client`
-time: 2023-06-21T18:17:18.419825-06:00
-custom:
-  Issue: "898"

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Python.
 ## Features
 
 - Supports the full RPC API via the [`Session` class](https://citric.readthedocs.io/en/latest/_api/citric/session/index.html#citric.session.Session).
-- Best effort to implement all the RPC methods in the [`Client` class](https://citric.readthedocs.io/en/latest/_api/citric/client/index.html#citric.client.Client). See the [API coverage page](https://citric.readthedocs.io/en/latest/rpc_coverage.html) for details.
-- Easily export survey data to CSV files, [Pandas DataFrames](https://citric.readthedocs.io/en/latest/how-to.html#export-responses-to-a-pandas-dataframe) and [DuckDB databases](https://citric.readthedocs.io/en/latest/how-to.html#export-responses-to-a-duckdb-database-and-analyze-with-sql).
-- Easily [download survey files](https://citric.readthedocs.io/en/latest/how-to.html#get-files-uploaded-to-a-survey-and-move-them-to-s3) (e.g. images, audio, etc.) to a local directory.
+- Best effort to implement all the RPC methods in the [`Client` class](https://citric.readthedocs.io/en/stable/_api/citric/index.html#citric.Client). See the [API coverage page](https://citric.readthedocs.io/en/stable/rpc_coverage.html) for details.
+- Easily export survey data to CSV files, [Pandas DataFrames](https://citric.readthedocs.io/en/stable/how-to.html#export-responses-to-a-pandas-dataframe) and [DuckDB databases](https://citric.readthedocs.io/en/stable/how-to.html#export-responses-to-a-duckdb-database-and-analyze-with-sql).
+- Easily [download survey files](https://citric.readthedocs.io/en/stable/how-to.html#get-files-uploaded-to-a-survey-and-move-them-to-s3) (e.g. images, audio, etc.) to a local directory.
 - Tested against LimeSurvey 6.0.0+ and 5.0.0+ LTS versions.
 
 ## Installation
@@ -82,7 +82,7 @@ Code samples and API documentation are available at [citric.readthedocs.io](http
 
 ## Contributing
 
-If you'd like to contribute to this project, please see the [contributing guide](https://citric.readthedocs.io/en/latest/contributing/getting-started.html).
+If you'd like to contribute to this project, please see the [contributing guide](https://citric.readthedocs.io/en/stable/contributing/getting-started.html).
 
 ## Credits
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,11 +3,7 @@
 from __future__ import annotations
 
 import sys
-import typing as t
 from pathlib import Path
-
-if t.TYPE_CHECKING:
-    from sphinx.application import Sphinx
 
 sys.path.append(str(Path("./_ext").resolve()))
 
@@ -91,39 +87,3 @@ def linkcode_resolve(domain: str, info: dict) -> str | None:
         return None
     filename = info["module"].replace(".", "/")
     return f"https://github.com/edgarrmondragon/citric/tree/main/src/{filename}.py"
-
-
-def skip_member_filter(
-    app: Sphinx,  # noqa: ARG001
-    what: str,  # noqa: ARG001
-    name: str,
-    obj: t.Any,  # noqa: ARG001, ANN401
-    skip: bool,  # noqa: FBT001
-    options: t.Any,  # noqa: ARG001, ANN401
-) -> bool | None:
-    """Filter autoapi members.
-
-    Args:
-        app: Sphinx application object.
-        what: The type of the object which the docstring belongs to.
-        name: The fully qualified name of the object.
-        obj: The object itself.
-        skip: Whether AutoAPI will skip this member if the handler does not override
-            the decision.
-        options: The options given to the directive.
-
-    Returns:
-        Whether to skip the member.
-    """
-    if name == "citric.client.Client":
-        skip = True
-    return skip
-
-
-def setup(sphinx: Sphinx) -> None:
-    """Setup function.
-
-    Args:
-        sphinx: Sphinx application object.
-    """
-    sphinx.connect("autoapi-skip-member", skip_member_filter)


### PR DESCRIPTION
- Revert "docs: Deduplicate `citric.Client` docs (#898)"
- Revert "chore: Add change file"


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--920.org.readthedocs.build/en/920/

<!-- readthedocs-preview citric end -->