### PR TITLE
refactor: Use `__all__` to expose public API

### DIFF
--- a/.changes/unreleased/Refactored-20230815-200414.yaml
+++ b/.changes/unreleased/Refactored-20230815-200414.yaml
@@ -1,0 +1,5 @@
+kind: Refactored
+body: Use `__all__` to expose public API
+time: 2023-08-15T20:04:14.027511-06:00
+custom:
+  Issue: "935"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -34,6 +34,13 @@ if t.TYPE_CHECKING:
     else:
         from typing_extensions import Self, Unpack
 
+__all__ = [
+    "QuestionReference",
+    "FileMetadata",
+    "UploadedFile",
+    "Client",
+]
+
 EMAILS_SENT_STATUS_PATTERN = re.compile(r"(-?\d+) left to send")
 
 

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -4,6 +4,21 @@ from __future__ import annotations
 
 import enum
 
+__all__ = [
+    "StringEnum",
+    "ImportGroupType",
+    "ImportSurveyType",
+    "NewSurveyType",
+    "StatisticsExportFormat",
+    "ResponsesExportFormat",
+    "SurveyCompletionStatus",
+    "HeadingType",
+    "ResponseType",
+    "TimelineAggregationPeriod",
+    "QuotaAction",
+    "EmailSendStrategy",
+]
+
 
 class StringEnum(str, enum.Enum):
     """Enum with string values."""

--- a/src/citric/method.py
+++ b/src/citric/method.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import typing as t
 
+__all__ = ["Method"]
+
 T = t.TypeVar("T")
 
 

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -18,6 +18,22 @@ else:
 if t.TYPE_CHECKING:
     from citric import enums
 
+__all__ = [
+    "Result",
+    "FileUploadResult",
+    "GroupProperties",
+    "LanguageProperties",
+    "OperationStatus",
+    "QuestionsListElement",
+    "QuestionProperties",
+    "QuotaListElement",
+    "QuotaProperties",
+    "RPCResponse",
+    "SetQuotaPropertiesResult",
+    "SurveyProperties",
+    "CPDBParticipantImportResult",
+]
+
 Result: TypeAlias = t.Any
 YesNo: TypeAlias = Literal["Y", "N"]
 


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--935.org.readthedocs.build/en/935/

<!-- readthedocs-preview citric end -->