### PR TITLE
chore: Remove sphinx-autodoc-typehints from docs extra

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ hoverxref_role_types = {
     "hoverxref": "tooltip",
     "ref": "modal",
     "mod": "modal",
-    "class": "modal",
+    "class": "tooltip",
 }
 
 extlinks = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ docs = [
   "sphinx",
   "sphinx-autoapi",
   "sphinx-autobuild",
-  "sphinx-autodoc-typehints",
   "sphinx-copybutton",
   "sphinx-hoverxref",
 ]


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--938.org.readthedocs.build/en/938/

<!-- readthedocs-preview citric end -->