### PR TITLE
chore: Drop tests on deprecated PyPy 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,6 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
-        - "pypy3.8"
         - "pypy3.9"
         - "pypy3.10"
         os: ["ubuntu-latest"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ TEST_DEPS = ["coverage[toml]", "faker", "pytest", "python-dotenv"]
 package = "citric"
 
 python_versions = ["3.11", "3.10", "3.9", "3.8"]
-pypy_versions = ["pypy3.8", "pypy3.9", "pypy3.10"]
+pypy_versions = ["pypy3.9", "pypy3.10"]
 all_python_versions = python_versions + pypy_versions
 
 main_cpython_version = "3.11"


### PR DESCRIPTION
- chore: Upload wheel signatures to release
- chore: Drop tests on deprecated PyPy 3.8


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--945.org.readthedocs.build/en/945/

<!-- readthedocs-preview citric end -->