### PR TITLE
chore: Re-enable tests against Python 3.13 (alpha)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,11 +74,11 @@ jobs:
           experimental: true
           nightly: true
 
-        # - python-version: "3.13"
-        #   os: "ubuntu-latest"
-        #   session: "tests"
-        #   experimental: true
-        #   nightly: true
+        - python-version: "3.13"
+          os: "ubuntu-latest"
+          session: "tests"
+          experimental: true
+          nightly: true
 
         - python-version: "3.12"
           os: "windows-latest"


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
:books: Documentation preview :books:: https://citric--999.org.readthedocs.build/en/999/

<!-- readthedocs-preview citric end -->