### PR TITLE
docs: Document `surveyls_legal_notice` language attribute

### DIFF
--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -106,6 +106,9 @@ class LanguageProperties(t.TypedDict, total=False):
     surveyls_policy_notice: str | None
     """The survey policy notice."""
 
+    surveyls_legal_notice: str | None
+    """The survey legal notice."""
+
     surveyls_policy_error: str | None
     """The survey policy error."""
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,3 +47,9 @@ def survey_id(client: citric.Client) -> t.Generator[int, None, None]:
 def server_version(client: citric.Client) -> semver.Version:
     """Get the server version."""
     return semver.Version.parse(client.get_server_version())
+
+
+@pytest.fixture(scope="session")
+def database_version(client: citric.Client) -> int:
+    """Get the LimeSurvey database schema version."""
+    return client._get_site_setting("dbversionnumber")

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -73,19 +73,33 @@ def test_fieldmap(client: citric.Client, survey_id: int, subtests: SubTests):
 
 
 @pytest.mark.integration_test
-def test_language(client: citric.Client, survey_id: int):
+def test_language(
+    client: citric.Client,
+    database_version: int,
+    survey_id: int,
+    subtests: SubTests,
+):
     """Test language methods."""
     # Add a new language
     assert client.add_language(survey_id, "es")["status"] == "OK"
     assert client.add_language(survey_id, "ru")["status"] == "OK"
 
     survey_props = client.get_survey_properties(survey_id)
-    assert survey_props["additional_languages"] == "es ru"
+    with subtests.test(msg="additional languages are correct"):
+        assert survey_props["additional_languages"] == "es ru"
 
     # Get language properties
     language_props = client.get_language_properties(survey_id, language="es")
     assert language_props["surveyls_email_register_subj"] is not None
     assert language_props["surveyls_email_invite"] is not None
+
+    with subtests.test(msg="legal notice is present"):
+        if database_version < 622:  # sourcery skip: no-conditionals-in-tests
+            pytest.xfail(
+                "The legal notice field is not supported in LimeSurvey database version"
+                f" {database_version} < 622"
+            )
+        assert "surveyls_legal_notice" in language_props
 
     # Update language properties
     new_confirmation = "Thank you for participating!"
@@ -94,21 +108,24 @@ def test_language(client: citric.Client, survey_id: int):
         language="es",
         surveyls_email_confirm=new_confirmation,
     )
-    assert response == {"status": "OK", "surveyls_email_confirm": True}
+    with subtests.test(msg="updated language properties"):
+        assert response == {"status": "OK", "surveyls_email_confirm": True}
 
     new_props = client.get_language_properties(
         survey_id,
         language="es",
         settings=["surveyls_email_confirm"],
     )
-    assert new_props["surveyls_email_confirm"] == new_confirmation
+    with subtests.test(msg="read updated language properties"):
+        assert new_props["surveyls_email_confirm"] == new_confirmation
 
     # Delete language
     delete_response = client.delete_language(survey_id, "ru")
     assert delete_response["status"] == "OK"
 
     props_after_delete_language = client.get_survey_properties(survey_id)
-    assert props_after_delete_language["additional_languages"] == "es"
+    with subtests.test(msg="language is deleted"):
+        assert props_after_delete_language["additional_languages"] == "es"
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
* Wait for https://github.com/LimeSurvey/LimeSurvey/pull/3680 to be merged


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1067.org.readthedocs.build/en/1067/

<!-- readthedocs-preview citric end -->