### PR TITLE
docs: Add admonition for `surveyls_legal_notice`

### DIFF
--- a/.changes/unreleased/Documentation-20240104-220929.yaml
+++ b/.changes/unreleased/Documentation-20240104-220929.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Document `surveyls_legal_notice` survey language attribute
+time: 2024-01-04T22:09:29.319672-06:00
+custom:
+  Issue: "1067"

--- a/docs/_ext/limesurvey_future.py
+++ b/docs/_ext/limesurvey_future.py
@@ -21,7 +21,7 @@ class UnreleasedFeature(Directive):
     """
 
     required_arguments = 1
-    message = "This method is only supported in LimeSurvey >= {next_version}."
+    message = "This feature is only supported in LimeSurvey >= {next_version}."
     admonition_type = nodes.warning
 
     def run(self) -> list[nodes.Node]:
@@ -55,7 +55,7 @@ class ReleasedFeature(UnreleasedFeature):
     Adds a note to features only available after some release of LimeSurvey.
     """
 
-    message = "This method is only supported in LimeSurvey >= {next_version}."
+    message = "This feature is only supported in LimeSurvey >= {next_version}."
     admonition_type = nodes.note
 
 

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -107,7 +107,10 @@ class LanguageProperties(t.TypedDict, total=False):
     """The survey policy notice."""
 
     surveyls_legal_notice: str | None
-    """The survey legal notice."""
+    """The survey legal notice.
+
+    .. future:: 6.5.0
+    """
 
     surveyls_policy_error: str | None
     """The survey policy error."""


### PR DESCRIPTION
https://citric--1070.org.readthedocs.build/en/1070/_api/citric/types/index.html#citric.types.LanguageProperties.surveyls_legal_notice

<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1070.org.readthedocs.build/en/1070/

<!-- readthedocs-preview citric end -->