### PR TITLE
fix!: Remove deprecated `Session._headers` attribute

### DIFF
--- a/.changes/unreleased/Removed-20240208-014432.yaml
+++ b/.changes/unreleased/Removed-20240208-014432.yaml
@@ -1,0 +1,5 @@
+kind: Removed
+body: Removed the `Session._headers` attribute
+time: 2024-02-08T01:44:32.587864-06:00
+custom:
+  Issue: "1093"

--- a/src/citric/session.py
+++ b/src/citric/session.py
@@ -95,10 +95,6 @@ class Session:
 
     USER_AGENT = f"citric/{metadata.version('citric')}"
 
-    # TODO(edgarrmondragon): Remove this.
-    # https://github.com/edgarrmondragon/citric/issues/893
-    _headers: t.ClassVar[dict[str, t.Any]] = {}
-
     def __init__(
         self,
         url: str,
@@ -112,7 +108,6 @@ class Session:
         self.url = url
         self._session = requests_session or requests.session()
         self._session.headers["User-Agent"] = self.USER_AGENT
-        self._session.headers.update(self._headers)
         self._encoder = json_encoder or json.JSONEncoder
 
         self.__key: str | None = self.get_session_key(


### PR DESCRIPTION
Closes https://github.com/edgarrmondragon/citric/issues/893

<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1093.org.readthedocs.build/en/1093/

<!-- readthedocs-preview citric end -->