### PR TITLE
chore: Bump `coverage` to  7.4.2 to only use "sysmon" when available

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ locations = "src", "tests", "noxfile.py", "docs/conf.py"
 
 
 def _run_tests(session: Session, *args: str) -> None:
-    env = {"COVERAGE_CORE": "sysmon"} if session.python in {"3.12", "3.13"} else {}
+    env = {"COVERAGE_CORE": "sysmon"}
     try:
         session.run("coverage", "run", "-m", "pytest", *args, env=env)
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.docs = [
   "sphinx-notfound-page",
 ]
 optional-dependencies.tests = [
-  "coverage[toml]>=7.4",
+  "coverage[toml]>=7.4.2",
   "deptry>=0.12",
   "faker>=19",
   "pytest>=7.3.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,15 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
                 _add_integration_skip(item, value, reason)
 
 
+def pytest_report_header() -> list[str]:
+    """Return a list of strings to be displayed in the header of the report."""
+    return [
+        f"{key}: {value}"
+        for key, value in os.environ.items()
+        if key.startswith(("COVERAGE_", "NOX_"))
+    ]
+
+
 @pytest.fixture(scope="session")
 def integration_url(request: pytest.FixtureRequest) -> str:
     """LimeSurvey URL."""


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1099.org.readthedocs.build/en/1099/

<!-- readthedocs-preview citric end -->