### PR TITLE
fix: Bump min `requests` to `2.25.1` (released 2020-12-16)

### DIFF
--- a/.changes/unreleased/Fixed-20240222-213639.yaml
+++ b/.changes/unreleased/Fixed-20240222-213639.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: 'fix: Bump min `requests` to `2.25.1` (released 2020-12-16)'
+time: 2024-02-22T21:36:39.833205-06:00
+custom:
+  Issue: "1101"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "requests>=2.23",
+  "requests>=2.25.1",
 ]
 optional-dependencies.dev = [
   "citric[docs,tests,typing]",
@@ -65,11 +65,11 @@ optional-dependencies.tests = [
   "coverage[toml]>=7.4.2",
   "deptry>=0.12",
   "faker>=19",
-  "pytest>=7.3.1",
+  "pytest>=8",
   "pytest-github-actions-annotate-failures>=0.1.7",
-  "pytest-httpserver",
-  "pytest-reverse",
-  "pytest-subtests",
+  "pytest-httpserver>=1.0.8",
+  "pytest-reverse>=1.7",
+  "pytest-subtests>=0.11",
   "python-dotenv>=1",
   "semver>=3.0.1",
   "tinydb>=4.8",


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1101.org.readthedocs.build/en/1101/

<!-- readthedocs-preview citric end -->