### PR TITLE
chore: Remove redundant Ruff `target-version` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ source = "vcs"
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 line-length = 88
 src = ["src", "tests", "docs"]
-target-version = "py38"
 
 [tool.ruff.lint]
 explicit-preview-rules = false


### PR DESCRIPTION


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1102.org.readthedocs.build/en/1102/

<!-- readthedocs-preview citric end -->