### PR TITLE
chore: Add Python 3.14 trove classifier

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,14 @@ nox.options.default_venv_backend = "uv|virtualenv"
 
 package = "citric"
 
-python_versions = ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
+python_versions = [
+    "3.13",
+    "3.12",
+    "3.11",
+    "3.10",
+    "3.9",
+    "3.8",
+]
 pypy_versions = ["pypy3.9", "pypy3.10"]
 all_python_versions = python_versions + pypy_versions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -262,7 +263,7 @@ DEP004 = [
 ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Blocked by https://github.com/pypi/warehouse/pull/15969 and a deployment of PyPI.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1146.org.readthedocs.build/en/1146/

<!-- readthedocs-preview citric end -->