### PR TITLE
ci: Test with free-threaded Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.inputs.tag || github.ref }}
-    - uses: hynek/build-and-inspect-python-package@2dbbf2b252d3a3c7cec7a810e3ed5983bd17b13a # v2.8.0
+    - uses: hynek/build-and-inspect-python-package@73aea398b9c8de9ea9e4464c6b13cb8b1f3d6294 # v2.9.0
 
   upload-to-release:
     name: Upload to GitHub Release
@@ -62,7 +62,7 @@ jobs:
       with:
         name: Packages
         path: dist
-    - uses: pypa/gh-action-pypi-publish@8a08d616893759ef8e1aa1f2785787c0b97e20d6 # v1.10.0
+    - uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
 
   # Move this up when PyPI supports signing
   sign:
@@ -80,7 +80,7 @@ jobs:
         with:
           name: Packages
           path: dist
-      - uses: actions/attest-build-provenance@6149ea5740be74af77f260b9db67e633f6b0a9a1 # v1.4.2
+      - uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         id: attest
         with:
           subject-path: "./dist/citric*"

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      uses: peter-evans/create-pull-request@6cd32fd93684475c31847837f87bb135d40a2b79 # v7.0.3
       with:
         token: ${{ steps.generate-token.outputs.token }}
         title: "chore: Release ${{ steps.latest.outputs.output }}"

--- a/.github/workflows/gha-update.yml
+++ b/.github/workflows/gha-update.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: '3.x'
-    - uses: hynek/setup-cached-uv@4b4bfa932036976749a9653b0fa4fa10b1a7092b # v2.1.0
+    - uses: hynek/setup-cached-uv@3e2b834ff80f67c4f272449b9f1aa388c294ae48 # v2.2.1
     - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
       id: generate-token
       with:
@@ -25,7 +25,7 @@ jobs:
         private_key: ${{ secrets.APP_PRIVATE_KEY }}
     - run: |
         uvx gha-update
-    - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+    - uses: peter-evans/create-pull-request@6cd32fd93684475c31847837f87bb135d40a2b79 # v7.0.3
       with:
         token: ${{ steps.generate-token.outputs.token }}
         title: "chore: Update GitHub Actions"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -68,6 +68,6 @@ jobs:
 
     # Upload the results to GitHub's code scanning dashboard.
     - name: "Upload to code-scanning"
-      uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
+      uses: github/codeql-action/upload-sarif@8214744c546c1e5c8f03dde8fab3a7353211988d # v3.26.7
       with:
         sarif_file: results.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ env:
 
 jobs:
   tests:
-    name: "Test ${{ matrix.python-version }} ${{ matrix.nightly && '(nightly) ' || '' }}/ ${{ matrix.os }}"
+    name: "Test ${{ matrix.python-version }} ${{ matrix.nightly && '(nightly) ' || '' }}${{ matrix.nogil && 'No GIL ' || '' }}/ ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental || false }}
     env:
@@ -78,6 +78,11 @@ jobs:
           os: "macos-latest"
           session: "tests"
 
+        - python-version: "3.13"
+          os: "ubuntu-latest"
+          session: "tests"
+          nogil: true
+
     steps:
     - name: Check out the repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -85,7 +90,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup Python ${{ matrix.python-version }}
-      if: "${{ !matrix.nightly }}"
+      if: "${{ !matrix.nightly && !matrix.nogil }}"
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
@@ -97,10 +102,11 @@ jobs:
           .github/workflows/constraint.txt
 
     - name: Setup Python ${{ matrix.python-version }} (nightly)
-      if: "${{ matrix.nightly }}"
-      uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
+      if: "${{ matrix.nightly || matrix.nogil }}"
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
       with:
         python-version: "${{ matrix.python-version }}-dev"
+        nogil: ${{ matrix.nogil || false }}
 
     - name: Install tools
       uses: ./.github/actions/install-tools


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Help test free-threaded Python 3.13 in our dependencies.

## Test Plan

<!-- How was it tested? -->

CI should pass.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1148.org.readthedocs.build/en/1148/

<!-- readthedocs-preview citric end -->