### PR TITLE
test: Use `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` so some dev dependencies can be installed on Python 3.13+

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -95,7 +95,11 @@ def coverage(session: nox.Session) -> None:
 @nox.session(name="deps", python=python_versions)
 def dependencies(session: nox.Session) -> None:
     """Check issues with dependencies."""
-    session.install("-v", "citric[dev] @ .")
+    install_env = {}
+    if session.python in {"3.13", "3.14"}:
+        install_env["PYO3_USE_ABI3_FORWARD_COMPATIBILITY"] = "1"
+
+    session.install("-v", "citric[dev] @ .", env=install_env)
     session.install("-v", "deptry")
     session.run("deptry", "src", "tests", "docs")
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1151.org.readthedocs.build/en/1151/

<!-- readthedocs-preview citric end -->