### PR TITLE
docs: Fixed links to LimeSurvey API docs

### DIFF
--- a/.changes/unreleased/Documentation-20240528-231130.yaml
+++ b/.changes/unreleased/Documentation-20240528-231130.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Fix links to LimeSurvey API docs
+time: 2024-05-28T23:11:30.2632-06:00
+custom:
+    Issue: "9999"

--- a/.changes/unreleased/Documentation-20240528-231130.yaml
+++ b/.changes/unreleased/Documentation-20240528-231130.yaml
@@ -1,5 +1,5 @@
 kind: Documentation
-body: Fix links to LimeSurvey API docs
+body: Fixed links to LimeSurvey API docs
 time: 2024-05-28T23:11:30.2632-06:00
 custom:
-    Issue: "9999"
+    Issue: "1152"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,7 +87,7 @@ autodoc_typehints_description_target = "documented"
 
 extlinks = {
     "rpc_method": (
-        "https://api.limesurvey.org/classes/remotecontrol_handle.html#method_%s",
+        "https://api.limesurvey.org/classes/remotecontrol-handle.html#method_%s",
         "RPC method %s",
     ),
     "ls_manual": (


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Fixed links to LimeSurvey API docs after they refreshed their docs: https://api.limesurvey.org/classes/remotecontrol-handle.html.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/
