### PR TITLE
test: Test the `survey_name` parameter of `import_survey`

### DIFF
--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -6,6 +6,7 @@ import csv
 import io
 import json
 import operator
+import random
 import typing as t
 import uuid
 from datetime import datetime
@@ -158,6 +159,25 @@ def test_survey(client: citric.Client):
 
     new_props = client.get_survey_properties(survey_id, properties=["format"])
     assert new_props["format"] == enums.NewSurveyType.ALL_ON_ONE_PAGE
+
+
+@pytest.mark.integration_test
+def test_import_survey(client: citric.Client, subtests: SubTests):
+    """Test importing a survey with a custom ID and name."""
+    survey_id = random.randint(10000, 20000)  # noqa: S311
+    with Path("./examples/survey.lss").open("rb") as f:
+        imported_id = client.import_survey(
+            f,
+            survey_id=survey_id,
+            survey_name="Custom Name",
+        )
+
+    with subtests.test(msg="imported survey has custom ID"):
+        assert imported_id == survey_id
+
+    survey_props = client.get_language_properties(imported_id)
+    with subtests.test(msg="imported survey has custom name"):
+        assert survey_props["surveyls_title"] == "Custom Name"
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Test the `survey_name` parameter of `import_survey`

## Test Plan

<!-- How was it tested? -->

Add subtests to validate the custom survey ID and name.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1154.org.readthedocs.build/en/1154/

<!-- readthedocs-preview citric end -->