### PR TITLE
ci: Dropped integration test against `5.x` LimeSurvey branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,11 +238,6 @@ jobs:
 
         # Test Limesurvey/LimeSurvey branches
         - python-version: "3.12"
-          ref: refs/heads/5.x
-          context: https://github.com/martialblog/docker-limesurvey.git#master:5.0/apache
-          database: postgres
-
-        - python-version: "3.12"
           ref: refs/heads/develop
           context: https://github.com/martialblog/docker-limesurvey.git#master:6.0/apache
           database: postgres


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

The branch was deleted because support for 5.x ended on May 2024.

References:

* https://manual.limesurvey.org/LimeSurvey_roadmap#Limesurvey_5.x_-_First_release:_May_2021

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1165.org.readthedocs.build/en/1165/

<!-- readthedocs-preview citric end -->