### PR TITLE
feat(rpc): Test and document new top-level question attributes from LimeSurvey 6.6.4

### DIFF
--- a/.changes/unreleased/Refactored-20240921-212214.yaml
+++ b/.changes/unreleased/Refactored-20240921-212214.yaml
@@ -1,0 +1,5 @@
+kind: Refactored
+body: Test and document new top-level question attributes from LimeSurvey 6.6.3
+time: 2024-09-21T21:22:14.488817-06:00
+custom:
+    Issue: "1189"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.3
+  rev: v0.6.7
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
@@ -63,12 +63,12 @@ repos:
     args: [--all]
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: "2.2.1"
+  rev: "2.2.4"
   hooks:
   - id: pyproject-fmt
 
 - repo: https://github.com/astral-sh/uv-pre-commit
-  rev: 0.4.2
+  rev: 0.4.15
   hooks:
   - id: pip-compile
     files: ^pyproject\.toml$

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -253,6 +253,18 @@ class QuestionProperties(t.TypedDict, total=False):
     sid: int
     """The survey ID."""
 
+    question: str
+    """The question text in the survey language."""
+
+    help: str
+    """The question help text in the survey language."""
+
+    script: str
+    """The question script."""
+
+    questionl10ns: dict[str, t.Any]
+    """The question language-specific attributes."""
+
     type: str
     """The question type."""
 

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -211,7 +211,7 @@ def test_copy_survey_destination_id(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql(strict=True)
+# @pytest.mark.xfail_mysql(strict=True)
 def test_group(client: citric.Client, survey_id: int):
     """Test group methods."""
     # Import a group
@@ -251,8 +251,25 @@ def test_group(client: citric.Client, survey_id: int):
 
 
 @pytest.mark.integration_test
-def test_question(client: citric.Client, survey_id: int):
+def test_question(
+    request: pytest.FixtureRequest,
+    client: citric.Client,
+    server_version: semver.VersionInfo,
+    survey_id: int,
+):
     """Test question methods."""
+    request.applymarker(
+        pytest.mark.xfail(
+            server_version < (6, 6, 3),
+            reason=(
+                "The question text property (`question`) is not available in "
+                f"LimeSurvey {server_version} < 6.6.4"
+            ),
+            raises=KeyError,
+            strict=True,
+        ),
+    )
+
     group_id = client.add_group(survey_id, "Test Group")
 
     # Import a question from a lsq file
@@ -261,6 +278,13 @@ def test_question(client: citric.Client, survey_id: int):
 
     # Get question properties
     props = client.get_question_properties(question_id)
+
+    # test language-specific question properties
+    assert props["question"] == "<p>Text for <strong>first question</strong></p>"
+    assert not props["help"]
+    assert not props["script"]
+    assert isinstance(props["questionl10ns"], dict)
+
     assert int(props["gid"]) == group_id
     assert int(props["qid"]) == question_id
     assert int(props["sid"]) == survey_id
@@ -591,7 +615,7 @@ def test_responses(client: citric.Client, survey_id: int, tmp_path: Path):
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
+# @pytest.mark.xfail_mysql(strict=True)
 def test_file_upload(
     client: citric.Client,
     survey_id: int,
@@ -654,7 +678,7 @@ def test_file_upload_no_filename(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql(strict=True)
+# @pytest.mark.xfail_mysql(strict=True)
 def test_file_upload_invalid_extension(
     client: citric.Client,
     survey_id: int,

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -259,7 +259,7 @@ def test_question(
     """Test question methods."""
     request.applymarker(
         pytest.mark.xfail(
-            server_version < (6, 6, 3),
+            server_version < (6, 6, 4),
             reason=(
                 "The question text property (`question`) is not available in "
                 f"LimeSurvey {server_version} < 6.6.4"

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -615,7 +615,6 @@ def test_responses(client: citric.Client, survey_id: int, tmp_path: Path):
 
 
 @pytest.mark.integration_test
-# @pytest.mark.xfail_mysql(strict=True)
 def test_file_upload(
     client: citric.Client,
     survey_id: int,

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -211,7 +211,6 @@ def test_copy_survey_destination_id(
 
 
 @pytest.mark.integration_test
-# @pytest.mark.xfail_mysql(strict=True)
 def test_group(client: citric.Client, survey_id: int):
     """Test group methods."""
     # Import a group
@@ -677,7 +676,6 @@ def test_file_upload_no_filename(
 
 
 @pytest.mark.integration_test
-# @pytest.mark.xfail_mysql(strict=True)
 def test_file_upload_invalid_extension(
     client: citric.Client,
     survey_id: int,


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This was introduced by https://github.com/LimeSurvey/LimeSurvey/commit/c8df4cb38cf6f824f92f080a61197d203a57e517, and will be available starting with LimeSurvey **6.6.4**.

This includes the following attributes:

- `question`
- `help`
- `script`
- `questionl10ns`

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1189.org.readthedocs.build/en/1189/

<!-- readthedocs-preview citric end -->