### PR TITLE
test: Remove MySQL xfail markers

### DIFF
--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -211,7 +211,6 @@ def test_copy_survey_destination_id(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql(strict=True)
 def test_group(client: citric.Client, survey_id: int):
     """Test group methods."""
     # Import a group
@@ -591,7 +590,6 @@ def test_responses(client: citric.Client, survey_id: int, tmp_path: Path):
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
 def test_file_upload(
     client: citric.Client,
     survey_id: int,
@@ -622,7 +620,6 @@ def test_file_upload(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
 def test_file_upload_no_filename(
     client: citric.Client,
     survey_id: int,
@@ -654,7 +651,6 @@ def test_file_upload_no_filename(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql(strict=True)
 def test_file_upload_invalid_extension(
     client: citric.Client,
     survey_id: int,

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -620,6 +620,7 @@ def test_file_upload(
 
 
 @pytest.mark.integration_test
+@pytest.mark.xfail_mysql
 def test_file_upload_no_filename(
     client: citric.Client,
     survey_id: int,


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

  - Added `Client.invite_participants()`
  - `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[CONTRIBUTING]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
[Changie]: https://changie.dev/


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1194.org.readthedocs.build/en/1194/

<!-- readthedocs-preview citric end -->