### PR TITLE
ci: Use griffe GitHub output format

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,11 +10,11 @@
 
 <!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->
 
-- \[ \] My pull request has a descriptive title.
-- \[ \] I have read the [CONTRIBUTING] guide.
-- \[ \] I have added tests that prove my fix is effective or that my feature works.
-- \[ \] If appropriate, I have added necessary documentation.
-- \[ \] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].
+- [ ] My pull request has a descriptive title.
+- [ ] I have read the [CONTRIBUTING] guide.
+- [ ] I have added tests that prove my fix is effective or that my feature works.
+- [ ] If appropriate, I have added necessary documentation.
+- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].
 
 For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:
 

--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - src/**
     - .github/workflows/api-changes.yml
+    - .github/workflows/constraints.txt
     - CHANGELOG.md
 
 concurrency:

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
-griffe==1.3.2
+griffe>=1.4
 nox==2024.4.15
 pip==24.2
 pip-tools==7.4.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,4 @@ repos:
   rev: 0.7.17
   hooks:
   - id: mdformat
+    exclude: \.github/pull_request_template\.md

--- a/noxfile.py
+++ b/noxfile.py
@@ -165,6 +165,9 @@ def api_changes(session: nox.Session) -> None:
         "-s=src",
     ]
 
+    if GH_ACTIONS_ENV_VAR in os.environ:
+        args.append("-f=github")
+
     if session.posargs:
         args.append(f"-a={session.posargs[0]}")
 

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -345,7 +345,7 @@ class Client:  # noqa: PLR0904
 
     def delete_participants(
         self,
-        survey_id: int,
+        sid: int,
         participant_ids: t.Sequence[int],
     ) -> list[dict[str, t.Any]]:
         """Add participants to a survey.
@@ -353,7 +353,7 @@ class Client:  # noqa: PLR0904
         Calls :rpc_method:`delete_participants`.
 
         Args:
-            survey_id: Survey to delete participants to.
+            sid: Survey to delete participants to.
             participant_ids: Participant IDs to be deleted.
 
         Returns:
@@ -362,7 +362,7 @@ class Client:  # noqa: PLR0904
         .. versionadded:: 0.0.1
         """
         return self.session.delete_participants(
-            survey_id,
+            sid,
             participant_ids,
         )
 

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -345,7 +345,7 @@ class Client:  # noqa: PLR0904
 
     def delete_participants(
         self,
-        sid: int,
+        survey_id: int,
         participant_ids: t.Sequence[int],
     ) -> list[dict[str, t.Any]]:
         """Add participants to a survey.
@@ -353,7 +353,7 @@ class Client:  # noqa: PLR0904
         Calls :rpc_method:`delete_participants`.
 
         Args:
-            sid: Survey to delete participants to.
+            survey_id: Survey to delete participants to.
             participant_ids: Participant IDs to be deleted.
 
         Returns:
@@ -362,7 +362,7 @@ class Client:  # noqa: PLR0904
         .. versionadded:: 0.0.1
         """
         return self.session.delete_participants(
-            sid,
+            survey_id,
             participant_ids,
         )
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

https://mkdocstrings.github.io/griffe/guide/users/checking/#github

## Test Plan

<!-- How was it tested? -->

Introduce a breaking API change to confirm the output here.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1203.org.readthedocs.build/en/1203/

<!-- readthedocs-preview citric end -->