### PR TITLE
chore: Upload attestations to PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,9 @@ jobs:
         name: Packages
         path: dist
     - uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3
+      with:
+        attestations: true
 
-  # Move this up when PyPI supports signing
   sign:
     name: Sign the distribution package
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://github.com/pypa/gh-action-pypi-publish/tree/f7600683efdcb7656dec5b29656edb7bc586e597/?tab=readme-ov-file#generating-and-uploading-attestations

## Test Plan

<!-- How was it tested? -->

Make one or more dev releases to test things.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1206.org.readthedocs.build/en/1206/

<!-- readthedocs-preview citric end -->