### PR TITLE
feat: Support the new quota action options in LimeSurvey 6.6.7+

### DIFF
--- a/.changes/unreleased/Added-20241112-183538.yaml
+++ b/.changes/unreleased/Added-20241112-183538.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: 'feat: Support the new quota action options in LimeSurvey 6.6.7+'
+time: 2024-11-12T18:35:38.085807-06:00
+custom:
+    Issue: "1218"

--- a/docs/_ext/limesurvey_future.py
+++ b/docs/_ext/limesurvey_future.py
@@ -10,7 +10,14 @@ from docutils.parsers.rst import Directive
 if t.TYPE_CHECKING:
     from sphinx.application import Sphinx
 
-__all__ = ["ReleasedFeature", "UnreleasedFeature", "setup"]
+__all__ = [
+    "ReleasedAttribute",
+    "ReleasedFeature",
+    "ReleasedParameter",
+    "UnreleasedFeature",
+    "UnreleasedParameter",
+    "setup",
+]
 
 
 class UnreleasedFeature(Directive):
@@ -21,7 +28,7 @@ class UnreleasedFeature(Directive):
     """
 
     required_arguments = 1
-    message = "This method is only supported in LimeSurvey >= {next_version}."
+    message = "This method is only supported in LimeSurvey {next_version} and above."
     admonition_type = nodes.warning
 
     def run(self) -> list[nodes.Node]:
@@ -38,9 +45,7 @@ class UnreleasedParameter(Directive):
     """
 
     required_arguments = 2
-    message = (
-        "The parameter {parameter} is only supported in LimeSurvey >= {next_version}."
-    )
+    message = "The parameter {parameter} is only supported in LimeSurvey {next_version} and above."  # noqa: E501
     admonition_type = nodes.warning
 
     def run(self) -> list[nodes.Node]:
@@ -55,7 +60,7 @@ class ReleasedFeature(UnreleasedFeature):
     Adds a note to features only available after some release of LimeSurvey.
     """
 
-    message = "This method is only supported in LimeSurvey >= {next_version}."
+    message = "This method is only supported in LimeSurvey {next_version} and above."
     admonition_type = nodes.note
 
 
@@ -66,10 +71,19 @@ class ReleasedParameter(UnreleasedParameter):
     LimeSurvey.
     """
 
-    message = (
-        "The parameter {parameter} is only supported in LimeSurvey >= {next_version}."
-    )
+    message = "The parameter {parameter} is only supported in LimeSurvey {next_version} and above."  # noqa: E501
     admonition_type = nodes.note
+
+
+class ReleasedAttribute(ReleasedFeature):
+    """A directive for released attributes.
+
+    Adds a note to class attributes that are only available after some release of
+    LimeSurvey.
+    """
+
+    message = "The attribute is only supported in LimeSurvey {next_version} and above."
+    admonition_type = nodes.warning
 
 
 def setup(app: Sphinx) -> dict[str, t.Any]:
@@ -77,6 +91,7 @@ def setup(app: Sphinx) -> dict[str, t.Any]:
     app.add_directive("futureparam", UnreleasedParameter)
     app.add_directive("minlimesurvey", ReleasedFeature)
     app.add_directive("minlimesurveyparam", ReleasedParameter)
+    app.add_directive("minlimesurveyattribute", ReleasedAttribute)
 
     return {
         "version": "0.1",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,7 +91,7 @@ extlinks = {
         "RPC method %s",
     ),
     "ls_manual": (
-        "https://manual.limesurvey.org/%s",
+        "https://limesurvey.org/manual/%s",
         "%s",
     ),
     "ls_tag": (

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,9 @@ Release **v{sub-ref}`version`**. ([What's new?](./changelog.md))
 
 Integration tests are run against a LimeSurvey instance, and both PostgreSQL and MySQL backends, using Docker Compose. The following versions of LimeSurvey were tested for this release:
 
+- {ls_tag}`6.6.7+241028`
 - {ls_tag}`6.6.6+241002`
 - {ls_tag}`6.6.5+240924`
-- {ls_tag}`6.6.4+240923`
 - {ls_tag}`5.6.68+240625`
 - {ls_tag}`5.6.67+240612`
 - {ls_tag}`5.6.66+240604`

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -284,6 +284,9 @@ class Client:  # noqa: PLR0904
 
         Calls :rpc_method:`add_quota`.
 
+        You can read more about quotas in the
+        :ls_manual:`LimeSurvey manual <Survey_quotas>`.
+
         Args:
             survey_id: ID of the survey to add the quota to.
             name: Name of the quota.
@@ -589,6 +592,9 @@ class Client:  # noqa: PLR0904
         """Delete a LimeSurvey quota.
 
         Calls :rpc_method:`delete_quota`.
+
+        You can read more about quotas in the
+        :ls_manual:`LimeSurvey manual <Survey_quotas>`.
 
         Args:
             quota_id: ID of the quota to delete.
@@ -972,6 +978,9 @@ class Client:  # noqa: PLR0904
         """Get properties of a LimeSurvey quota.
 
         Calls :rpc_method:`get_quota_properties`.
+
+        You can read more about quotas in the
+        :ls_manual:`LimeSurvey manual <Survey_quotas>`.
 
         Args:
             quota_id: ID of the quota to get properties for.
@@ -1459,6 +1468,9 @@ class Client:  # noqa: PLR0904
 
         Calls :rpc_method:`list_quotas`.
 
+        You can read more about quotas in the
+        :ls_manual:`LimeSurvey manual <Survey_quotas>`.
+
         Args:
             survey_id: ID of the survey to get quotas for.
 
@@ -1600,6 +1612,9 @@ class Client:  # noqa: PLR0904
         """Set properties of a quota.
 
         Calls :rpc_method:`set_quota_properties`.
+
+        You can read more about quotas in the
+        :ls_manual:`LimeSurvey manual <Survey_quotas>`.
 
         Args:
             quota_id: Quota ID.

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -102,7 +102,25 @@ class QuotaAction(StringEnum):
     """Quota action."""
 
     TERMINATE = "terminate"
+    """Terminate after related visible question was submitted."""
+
     CONFIRM_TERMINATE = "confirm_terminate"
+    """Soft terminate after related visible question was submitted, answer will be
+    editable."""
+
+    TERMINATE_VISIBLE_HIDDEN = "terminate_visible_hidden"
+    """Terminate after related visible and hidden questions were submitted.
+
+    .. versionadded:: NEXT_VERSION
+    .. minlimesurveyattribute:: 6.6.7
+    """
+
+    TERMINATE_PAGES = "terminate_pages"
+    """Terminate after all page submissions.
+
+    .. versionadded:: NEXT_VERSION
+    .. minlimesurveyattribute:: 6.6.7
+    """
 
     @property
     def integer_value(self) -> int:
@@ -114,6 +132,8 @@ class QuotaAction(StringEnum):
         mapping = {
             self.TERMINATE: 1,
             self.CONFIRM_TERMINATE: 2,
+            self.TERMINATE_VISIBLE_HIDDEN: 3,
+            self.TERMINATE_PAGES: 4,
         }
         return mapping[self]
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://github.com/LimeSurvey/LimeSurvey/commit/f1c0dae7b7317958192a715776861b57744f0d9e#diff-22d09ac4b2de7e29721c3fc14eb239f215498a280b8c37f4b718074646f01f5dR2545
- https://github.com/LimeSurvey/LimeSurvey/pull/3994

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1218.org.readthedocs.build/en/1218/

<!-- readthedocs-preview citric end -->