### PR TITLE
ci: Soft-removal of Python 3.8 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -24,14 +24,12 @@ body:
       label: Python Version
       description: Version of Python you are using
       options:
-        - "3.6 (deprecated)"
-        - "3.7 (deprecated)"
-        - "3.8"
-        - "3.9"
-        - "3.10"
-        - "3.11"
-        - "3.12"
         - "3.13"
+        - "3.12"
+        - "3.11"
+        - "3.10"
+        - "3.9"
+        - "3.8 or earlier"
         - "NA"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
@@ -64,19 +63,19 @@ jobs:
         - "pypy3.10"
         os: ["ubuntu-latest"]
         include:
+        - python-version: "3.8"
+          os: "ubuntu-latest"
+
         - python-version: "3.14"
           os: "ubuntu-latest"
-          session: "tests"
           experimental: true
           nightly: true
 
         - python-version: "3.13"
           os: "windows-latest"
-          session: "tests"
 
         - python-version: "3.13"
           os: "macos-latest"
-          session: "tests"
 
     steps:
     - name: Check out the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,14 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.4
+  rev: 0.30.0
   hooks:
   - id: check-dependabot
   - id: check-github-workflows
   - id: check-readthedocs
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.0
+  rev: v0.8.1
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
   jobs:
     post_checkout:
       - git fetch --unshallow || true

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,9 @@ Release **v{sub-ref}`version`**. ([What's new?](./changelog.md))
 
 Integration tests are run against a LimeSurvey instance, and both PostgreSQL and MySQL backends, using Docker Compose. The following versions of LimeSurvey were tested for this release:
 
+- {ls_tag}`6.8.0+241119`
 - {ls_tag}`6.6.7+241028`
 - {ls_tag}`6.6.6+241002`
-- {ls_tag}`6.6.5+240924`
 - {ls_tag}`5.6.68+240625`
 - {ls_tag}`5.6.67+240612`
 - {ls_tag}`5.6.66+240604`

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,12 +25,12 @@ nox.options.default_venv_backend = "uv"
 package = "citric"
 
 python_versions = [
+    "3.14",
     "3.13",
     "3.12",
     "3.11",
     "3.10",
     "3.9",
-    "3.8",
 ]
 pypy_versions = ["pypy3.10"]
 all_python_versions = python_versions + pypy_versions


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html


<!-- readthedocs-preview citric start -->
----
📚 Documentation preview 📚: https://citric--1219.org.readthedocs.build/en/1219/

<!-- readthedocs-preview citric end -->