### PR TITLE
typing: Add type annotations for quota language settings and test those attributes

### DIFF
--- a/.changes/unreleased/Typing-20241210-194942.yaml
+++ b/.changes/unreleased/Typing-20241210-194942.yaml
@@ -1,0 +1,5 @@
+kind: Typing
+body: 'Add type annotations for quota language settings and test those attributes'
+time: 2024-12-10T19:49:42.152857-06:00
+custom:
+    Issue: "1230"

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -369,6 +369,17 @@ class QuotaProperties(t.TypedDict, total=False):
     autoload_url: int
     """Whether the quota autoload URL is active."""
 
+    # Quota Language Settings
+
+    quotals_message: str
+    """Quota message for this language."""
+
+    quotals_url: str
+    """Quota end-URL for this language."""
+
+    quotals_urldescrip: str
+    """Quota end-URL description for this language."""
+
 
 class RPCResponse(t.TypedDict):
     """RPC response payload."""

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -369,6 +369,9 @@ class QuotaProperties(t.TypedDict, total=False):
     autoload_url: int
     """Whether the quota autoload URL is active."""
 
+    completeCount: int
+    """Count of completed interviews for this quota."""
+
     # Quota Language Settings
 
     quotals_message: str

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -378,6 +378,7 @@ def test_quota(
     client: citric.Client,
     server_version: semver.VersionInfo,
     survey_id: int,
+    subtests: SubTests,
 ):
     """Test quota methods."""
     request.applymarker(
@@ -418,9 +419,10 @@ def test_quota(
     assert int(props["action"]) == enums.QuotaAction.TERMINATE.integer_value
 
     # Language-specific quota properties
-    assert props["quotals_message"] == "No more responses allowed"
-    assert props["quotals_url"] == "https://example.com"
-    assert props["quotals_url_description"] == "Learn more"
+    with subtests.test(msg="language-specific quota properties"):
+        assert props["quotals_message"] == "No more responses allowed"
+        assert props["quotals_url"] == "https://example.com"
+        assert props["quotals_urldescrip"] == "Learn more"
 
     # Set quota properties
     response = client.set_quota_properties(quota_id, qlimit=150)

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -395,7 +395,14 @@ def test_quota(
     with pytest.raises(LimeSurveyStatusError, match="No quotas found"):
         client.list_quotas(survey_id)
 
-    quota_id = client.add_quota(survey_id, "Test Quota", 100)
+    quota_id = client.add_quota(
+        survey_id,
+        "Test Quota",
+        100,
+        message="No more responses allowed",
+        url="https://example.com",
+        url_description="Learn more",
+    )
 
     # List quotas
     quotas = client.list_quotas(survey_id)
@@ -409,6 +416,11 @@ def test_quota(
     assert int(props["qlimit"]) == 100
     assert int(props["active"]) == 1
     assert int(props["action"]) == enums.QuotaAction.TERMINATE.integer_value
+
+    # Language-specific quota properties
+    assert props["quotals_message"] == "No more responses allowed"
+    assert props["quotals_url"] == "https://example.com"
+    assert props["quotals_url_description"] == "Learn more"
 
     # Set quota properties
     response = client.set_quota_properties(quota_id, qlimit=150)

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -411,6 +411,7 @@ def test_quota(
     assert int(quotas[0]["id"]) == quota_id
 
     # Get quota properties
+    client.activate_survey(survey_id)
     props = client.get_quota_properties(quota_id)
     assert int(props["id"]) == quota_id
     assert props["name"] == "Test Quota"
@@ -423,6 +424,12 @@ def test_quota(
         assert props["quotals_message"] == "No more responses allowed"
         assert props["quotals_url"] == "https://example.com"
         assert props["quotals_urldescrip"] == "Learn more"
+
+    with subtests.test(msg="completeCount"):
+        if server_version < (6, 8, 2):
+            pytest.xfail("completeCount is not supported in LimeSurvey < 6.8.2")
+        props = client.get_quota_properties(quota_id)
+        assert int(props["completeCount"]) == 0
 
     # Set quota properties
     response = client.set_quota_properties(quota_id, qlimit=150)


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
