### PR TITLE
test: Fix `completeCount` version check

### DIFF
--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -426,8 +426,8 @@ def test_quota(
         assert props["quotals_urldescrip"] == "Learn more"
 
     with subtests.test(msg="completeCount"):
-        if server_version < (6, 8, 2):
-            pytest.xfail("completeCount is not supported in LimeSurvey < 6.8.2")
+        if server_version < (6, 9, 0):
+            pytest.xfail("completeCount is not supported in LimeSurvey < 6.9.0")
         props = client.get_quota_properties(quota_id)
         assert int(props["completeCount"]) == 0
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

It'll be version 6.9.0 that first introduces this, actually.

https://github.com/LimeSurvey/LimeSurvey/commit/3afde8b9d531b9b37b851057174d73977dfe875f.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
