### PR TITLE
feat(rpc): Added survey group ID input parameter to `list_surveys`

### DIFF
--- a/.changes/unreleased/Added-20241226-180149.yaml
+++ b/.changes/unreleased/Added-20241226-180149.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Added survey group ID input parameter to `list_surveys`
+time: 2024-12-26T18:01:49.207724-06:00
+custom:
+    Issue: "1242"

--- a/noxfile.py
+++ b/noxfile.py
@@ -143,7 +143,12 @@ def docs_serve(session: nox.Session) -> None:
         "docs",
         "build",
     ]
-    session.install("citric @ .", "-r", "requirements/requirements-docs.txt")
+    session.install(
+        "citric @ .",
+        "sphinx-autobuild",
+        "-r",
+        "requirements/requirements-docs.txt",
+    )
 
     build_dir = Path("build")
     if build_dir.exists():

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -878,9 +878,11 @@ class Client:  # noqa: PLR0904
             survey_id,
             enums.TimelineAggregationPeriod(period),
             start.isoformat(),
-            end.isoformat()
-            if end
-            else datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
+            (
+                end.isoformat()
+                if end
+                else datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+            ),
         )
 
     def get_group_properties(
@@ -1486,20 +1488,30 @@ class Client:  # noqa: PLR0904
         """
         return self.session.list_quotas(survey_id)
 
-    def list_surveys(self, username: str | None = None) -> list[dict[str, t.Any]]:
+    def list_surveys(
+        self,
+        username: str | None = None,
+        *,
+        survey_group_id: int | None = None,
+    ) -> list[dict[str, t.Any]]:
         """Get all surveys or only those owned by a user.
 
         Calls :rpc_method:`list_surveys`.
 
         Args:
             username: Owner of the surveys to retrieve.
+            survey_group_id: ID of the survey group to retrieve surveys from.
 
         Returns:
             List of surveys with basic information.
 
         .. versionadded:: 0.0.1
+           This method.
+
+        .. versionadded:: NEXT_VERSION
+           The *survey_group_id* parameter.
         """
-        return self.session.list_surveys(username)
+        return self.session.list_surveys(username, survey_group_id)
 
     def list_survey_groups(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -291,7 +291,7 @@ def test_list_groups(client: MockClient):
 
 def test_list_surveys(client: MockClient):
     """Test list_surveys client method."""
-    assert_client_session_call(client, "list_surveys", None)
+    assert_client_session_call(client, "list_surveys", None, survey_group_id=None)
 
 
 def test_list_survey_groups(client: MockClient):


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://github.com/LimeSurvey/LimeSurvey/commit/b5f78d6ff580ddd4edb7c0fb0e0a4d461dab01dc

## Test Plan

<!-- How was it tested? -->

- Add a subtest for the `gsid` input and output parameter.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
