### PR TITLE
typing(rpc): Richer annotation for the return type of `list_surveys`

### DIFF
--- a/.changes/unreleased/Typing-20250103-101152.yaml
+++ b/.changes/unreleased/Typing-20250103-101152.yaml
@@ -1,0 +1,5 @@
+kind: Typing
+body: Richer annotation for the return type of `list_surveys`
+time: 2025-01-03T10:11:52.478901-06:00
+custom:
+    Issue: "1245"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1493,7 +1493,7 @@ class Client:  # noqa: PLR0904
         username: str | None = None,
         *,
         survey_group_id: int | None = None,
-    ) -> list[dict[str, t.Any]]:
+    ) -> list[types.SurveyListElement]:
         """Get all surveys or only those owned by a user.
 
         Calls :rpc_method:`list_surveys`.

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -409,6 +409,31 @@ class SetQuotaPropertiesResult(t.TypedDict):
     """The quota properties."""
 
 
+class SurveyListElement(t.TypedDict, total=False):
+    """List surveys result."""
+
+    sid: int
+    """The survey ID."""
+
+    gsid: int
+    """The survey group ID.
+
+    .. minlimesurveyattribute:: 6.9.0
+    """
+
+    surveyls_title: str
+    """The survey title."""
+
+    startdate: str
+    """The survey start date."""
+
+    expires: str
+    """The survey expiration date."""
+
+    active: YesNo
+    """Whether the survey is active."""
+
+
 class SurveyProperties(t.TypedDict, total=False):
     """Survey properties result."""
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
