### PR TITLE
test: Replace MailHog with Mailpit

### DIFF
--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -19,7 +19,7 @@ services:
       ADMIN_USER: ${LS_USER:-iamadmin}
       ADMIN_NAME: Lime Administrator
       ADMIN_PASSWORD: ${LS_PASSWORD:-secret}
-      EMAIL_SMTPHOST: ${LS_SMTP_HOST:-mailhog:1025}
+      EMAIL_SMTPHOST: ${LS_SMTP_HOST:-mailpit:1025}
       EMAIL_SMTPUSER: ${LS_SMTP_USER:-citric@example.com}
       EMAIL_SMTPPASSWORD: ${LS_SMTP_PASSWORD:-secret}
     healthcheck:
@@ -43,8 +43,11 @@ services:
       timeout: 10s
       retries: 3
 
-  mailhog:
-    image: mailhog/mailhog
+  mailpit:
+    image: axllent/mailpit:v1.21
+    environment:
+      MP_SMTP_AUTH: "citric@example.com:secret"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
     ports:
       - "1025:1025"
       - "8025:8025"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,12 +161,6 @@ def integration_password(request: pytest.FixtureRequest) -> str:
 
 
 @pytest.fixture(scope="session")
-def integration_mailhog_url(request: pytest.FixtureRequest) -> str:
-    """MailHog URL."""
-    return request.config.getoption("--mailhog-url")
-
-
-@pytest.fixture(scope="session")
 def git_reference(request: pytest.FixtureRequest) -> str:
     """LimeSurvey git reference."""
     return request.config.getoption("--limesurvey-git-reference")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,20 +1,24 @@
-"""MailHog API client."""
+"""Mailpit API client."""
 
 from __future__ import annotations
 
 import requests
 
 
-class MailHogClient:
-    """MailHog API client."""
+class MailpitClient:
+    """Mailpit API client."""
 
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url
 
     def get_all(self) -> dict:
         """Get all messages."""
-        return requests.get(f"{self.base_url}/api/v2/messages", timeout=10).json()
+        return requests.get(f"{self.base_url}/api/v1/messages", timeout=10).json()
 
     def delete(self) -> None:
         """Delete all messages."""
-        requests.delete(f"{self.base_url}/api/v1/messages", timeout=10)
+        requests.delete(
+            f"{self.base_url}/api/v1/messages",
+            timeout=10,
+            params={"query": "after:2024/04/01"},
+        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,7 +14,7 @@ import semver
 
 import citric
 from citric.exceptions import LimeSurveyStatusError
-from tests.fixtures import MailHogClient
+from tests.fixtures import MailpitClient
 
 if t.TYPE_CHECKING:
     from pytest_docker.plugin import Services
@@ -99,14 +99,14 @@ def integration_url(docker_ip: str, docker_services: Services) -> str:
 
 
 @pytest.fixture(scope="session")
-def integration_mailhog_url(docker_ip: str, docker_services: Services) -> str:
+def integration_mailpit_url(docker_ip: str, docker_services: Services) -> str:
     """Ensure that the service is up and responsive."""
-    port = docker_services.port_for("mailhog", 8025)
+    port = docker_services.port_for("mailpit", 8025)
     url = f"http://{docker_ip}:{port}"
 
     def _check_connection() -> bool:
         try:
-            return requests.get(f"{url}/api/v2/messages", timeout=5).status_code == 200
+            return requests.get(f"{url}/api/v1/messages", timeout=5).status_code == 200
         except requests.RequestException:
             return False
 
@@ -161,8 +161,8 @@ def database_version(client: citric.Client) -> int:
 
 
 @pytest.fixture
-def mailhog(integration_mailhog_url: str) -> MailHogClient:
+def mailpit(integration_mailpit_url: str) -> MailpitClient:
     """Get the LimeSurvey database schema version."""
-    client = MailHogClient(integration_mailhog_url)
+    client = MailpitClient(integration_mailpit_url)
     client.delete()
     return client

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -26,7 +26,7 @@ if t.TYPE_CHECKING:
     from faker import Faker
     from pytest_subtests import SubTests
 
-    from tests.fixtures import MailHogClient
+    from tests.fixtures import MailpitClient
 
 NEW_SURVEY_NAME = "New Survey"
 
@@ -958,7 +958,7 @@ def test_mail_registered_participants(
     client: citric.Client,
     survey_id: int,
     participants: list[dict[str, str]],
-    mailhog: MailHogClient,
+    mailpit: MailpitClient,
     subtests: SubTests,
 ):
     """Test mail_registered_participants."""
@@ -971,7 +971,7 @@ def test_mail_registered_participants(
     )
 
     with subtests.test(msg="No initial emails"):
-        assert mailhog.get_all()["total"] == 0
+        assert mailpit.get_all()["total"] == 0
 
     # `mail_registered_participants` returns a non-error status messages even when
     # emails are sent successfully and that violates assumptions made by this
@@ -983,9 +983,9 @@ def test_mail_registered_participants(
         client.session.mail_registered_participants(survey_id)
 
     with subtests.test(msg="2 emails sent"):
-        assert mailhog.get_all()["total"] == 2
+        assert mailpit.get_all()["total"] == 2
 
-    mailhog.delete()
+    mailpit.delete()
 
     with pytest.raises(
         LimeSurveyStatusError,
@@ -994,7 +994,7 @@ def test_mail_registered_participants(
         client.session.mail_registered_participants(survey_id)
 
     with subtests.test(msg="No more emails sent"):
-        assert mailhog.get_all()["total"] == 0
+        assert mailpit.get_all()["total"] == 0
 
 
 @pytest.mark.integration_test
@@ -1002,7 +1002,7 @@ def test_remind_participants(
     client: citric.Client,
     survey_id: int,
     participants: list[dict[str, str]],
-    mailhog: MailHogClient,
+    mailpit: MailpitClient,
     subtests: SubTests,
 ):
     """Test remind_participants."""
@@ -1015,15 +1015,15 @@ def test_remind_participants(
     )
 
     with subtests.test(msg="No initial emails"):
-        assert mailhog.get_all()["total"] == 0
+        assert mailpit.get_all()["total"] == 0
 
     # Use `call` to avoid error handling
     client.session.call("mail_registered_participants", survey_id)
 
     with subtests.test(msg="2 emails sent"):
-        assert mailhog.get_all()["total"] == 2
+        assert mailpit.get_all()["total"] == 2
 
-    mailhog.delete()
+    mailpit.delete()
 
     # `remind_participants` returns a non-error status messages even when emails are
     # sent successfully and that violates assumptions made by this library about the
@@ -1032,4 +1032,4 @@ def test_remind_participants(
         client.session.remind_participants(survey_id)
 
     with subtests.test(msg="2 reminders sent"):
-        assert mailhog.get_all()["total"] == 2
+        assert mailpit.get_all()["total"] == 2


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://github.com/axllent/mailpit
- https://mailpit.axllent.org/docs/install/docker/
- https://mailpit.axllent.org/docs/api-v1/
- https://hub.docker.com/r/axllent/mailpit/tags
- https://mailpit.axllent.org/docs/configuration/smtp/#adding-smtp-authentication

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
