### PR TITLE
chore: Add `postUpgradeTasks` for `uv.lock`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,5 +61,23 @@
       "matchPackageNames": ["actions/upload-artifact", "actions/download-artifact"],
       "groupName": "GitHub artifact actions",
     },
-  ]
+  ],
+
+  // https://docs.renovatebot.com/configuration-options/#postupgradetasks
+  "postUpgradeTasks": {
+    "commands": [
+      // Export Docs Dependencies
+      "uv export --frozen --no-editable --output-file=requirements/requirements-docs.txt --only-group=docs",
+      // Export Test Dependencies
+      "uv export --frozen --output-file=requirements/requirements-test.txt --no-dev --only-group=test",
+      // Export Typing Dependencies
+      "uv export --frozen --output-file=requirements/requirements-typing.txt --only-group=typing",
+      // Export Runtime Dependencies
+      "uv export --frozen --output-file=requirements/requirements-highest.txt --no-dev --no-hashes --no-emit-project",
+    ],
+    "fileFilters": [
+      "uv.lock",
+    ],
+    "executionMode": "branch",
+  },
 }


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://docs.renovatebot.com/configuration-options/#postupgradetasks

From the docs

> [!NOTE]  
> Post-upgrade tasks can only be used on self-hosted Renovate instances.

## Test Plan

<!-- How was it tested? -->

Probably have to merge and check https://github.com/edgarrmondragon/citric/pull/1274 afterwards.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
