### PR TITLE
fix(deps): Rebase Renovate PRs automatically only when they are conflicted

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,7 @@
     }
   ],
 
+  # https://docs.renovatebot.com/configuration-options/#rebasewhen
   "rebaseWhen": "conflicted",
 
   // https://docs.renovatebot.com/configuration-options/#packagerules

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,6 @@
     // https://docs.renovatebot.com/presets-default/#prhourlylimitnone
     ":prHourlyLimitNone",
 
-    // https://docs.renovatebot.com/presets-default/#rebasestaleprs
-    ":rebaseStalePrs",
-
     // https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
     "customManagers:githubActionsVersions"
   ],
@@ -53,6 +50,8 @@
       ]
     }
   ],
+
+  "rebaseWhen": "conflicted",
 
   // https://docs.renovatebot.com/configuration-options/#packagerules
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,7 +51,7 @@
     }
   ],
 
-  # https://docs.renovatebot.com/configuration-options/#rebasewhen
+  // https://docs.renovatebot.com/configuration-options/#rebasewhen
   "rebaseWhen": "conflicted",
 
   // https://docs.renovatebot.com/configuration-options/#packagerules


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://docs.renovatebot.com/configuration-options/#rebasewhen
- https://docs.renovatebot.com/presets-default/#rebasestaleprs

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
