### PR TITLE
ci: Use setup-python to install Python 3.14 prerelease

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,8 @@ env:
 
 jobs:
   tests:
-    name: "Test ${{ matrix.python-version }} ${{ matrix.nightly && '(nightly) ' || '' }}/ ${{ matrix.os }}"
+    name: "Test ${{ matrix.python-version }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental || false }}
     permissions:
       contents: read
     env:
@@ -94,11 +93,9 @@ jobs:
         - python-version: "3.14"
           # renovate: datasource=github-runners depName=ubuntu
           os: ubuntu-24.04
-          experimental: true
-          nightly: true
 
         - python-version: "3.13"
-        # renovate: datasource=github-runners depName=windows
+          # renovate: datasource=github-runners depName=windows
           os: windows-2022
 
         - python-version: "3.13"
@@ -112,18 +109,11 @@ jobs:
         persist-credentials: false
 
     - name: Setup Python ${{ matrix.python-version }}
-      if: "${{ !matrix.nightly }}"
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
         allow-prereleases: true
-
-    - name: Setup Python ${{ matrix.python-version }} (nightly)
-      if: "${{ matrix.nightly }}"
-      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
-      with:
-        python-version: "${{ matrix.python-version }}-dev"
 
     - name: Install tools
       uses: ./.github/actions/install-tools
@@ -139,7 +129,7 @@ jobs:
       uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       with:
         include-hidden-files: true
-        name: "coverage-unit-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.nightly && 'nightly' || 'stable' }}"
+        name: "coverage-unit-${{ matrix.os }}-${{ matrix.python-version }}"
         path: ".coverage.*"
 
     - name: Upload test results to Codecov
@@ -148,7 +138,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: tests.xml
-        flags: unit-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.nightly && 'nightly' || 'stable' }}
+        flags: unit-${{ matrix.os }}-${{ matrix.python-version }}
 
     - name: Run Doctests
       run: |


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Use the `setup-python` GitHub action instead of `deadsnakes/action` to install Python 3.14 prerelease.

## Test Plan

<!-- How was it tested? -->

SSIA.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
