### PR TITLE
test: Ensure correct group and question are used in upload_file tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     integration_enabled = config.getoption("--integration")
     backend = config.getoption("--limesurvey-database-type")
 
-    xfail_mysql = pytest.mark.xfail(reason="This test fails on MySQL", strict=False)
+    xfail_mysql = pytest.mark.xfail(reason="This test fails on MySQL")
 
     for item in items:
         if backend == "mysql" and "xfail_mysql" in item.keywords:

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -854,7 +854,6 @@ def test_responses(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
 def test_file_upload(
     client: citric.Client,
     survey_id: int,
@@ -866,8 +865,13 @@ def test_file_upload(
     filepath.write_bytes(faker.zip())
 
     client.activate_survey(survey_id)
-    group = client.list_groups(survey_id)[1]
-    question = client.list_questions(survey_id, group["gid"])[0]
+    groups = client.list_groups(survey_id)
+    group = next(filter(lambda g: g["group_name"] == "Second Group", groups), None)
+    assert group is not None
+
+    questions = client.list_questions(survey_id, group["gid"])
+    question = next(filter(lambda q: q["title"] == "G02Q03", questions), None)
+    assert question is not None
 
     filename = "upload.zip"
     result = client.upload_file(
@@ -885,7 +889,6 @@ def test_file_upload(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
 def test_file_upload_no_filename(
     client: citric.Client,
     survey_id: int,
@@ -897,8 +900,13 @@ def test_file_upload_no_filename(
     filepath.write_bytes(faker.zip())
 
     client.activate_survey(survey_id)
-    group = client.list_groups(survey_id)[1]
-    question = client.list_questions(survey_id, group["gid"])[0]
+    groups = client.list_groups(survey_id)
+    group = next(filter(lambda g: g["group_name"] == "Second Group", groups), None)
+    assert group is not None
+
+    questions = client.list_questions(survey_id, group["gid"])
+    question = next(filter(lambda q: q["title"] == "G02Q03", questions), None)
+    assert question is not None
 
     result_no_filename = client.upload_file(
         survey_id,
@@ -917,7 +925,6 @@ def test_file_upload_no_filename(
 
 
 @pytest.mark.integration_test
-@pytest.mark.xfail_mysql
 def test_file_upload_invalid_extension(
     client: citric.Client,
     survey_id: int,
@@ -929,8 +936,13 @@ def test_file_upload_invalid_extension(
     filepath.write_bytes(faker.zip())
 
     client.activate_survey(survey_id)
-    group = client.list_groups(survey_id)[1]
-    question = client.list_questions(survey_id, group["gid"])[0]
+    groups = client.list_groups(survey_id)
+    group = next(filter(lambda g: g["group_name"] == "Second Group", groups), None)
+    assert group is not None
+
+    questions = client.list_questions(survey_id, group["gid"])
+    question = next(filter(lambda q: q["title"] == "G02Q03", questions), None)
+    assert question is not None
 
     with pytest.raises(
         LimeSurveyStatusError,


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
