### PR TITLE
feat: Added the `create_dir` parameter to `download_files`

### DIFF
--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1237,6 +1237,8 @@ class Client:  # noqa: PLR0904
         directory: str | Path,
         survey_id: int,
         token: str | None = None,
+        *,
+        create_dir: bool = True,
     ) -> list[Path]:
         """Download files uploaded in survey response.
 
@@ -1244,13 +1246,18 @@ class Client:  # noqa: PLR0904
             directory: Where to store the files.
             survey_id: Survey for which to download files.
             token: Optional participant token to filter uploaded files.
+            create_dir: Whether to create the directory if it doesn't exist.
 
         Returns:
             List with the paths of downloaded files.
 
         .. versionadded:: 0.0.1
+        .. versionchanged:: NEXT_VERSION
+           Added the ``create_dir`` optional parameter.
         """
         dirpath = Path(directory)
+        if create_dir:
+            dirpath.mkdir(parents=True, exist_ok=True)
 
         filepaths = []
         uploaded_files = self.get_uploaded_file_objects(survey_id, token=token)


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
