### PR TITLE
chore: Annotate argument to decorator as `types.FunctionType`

### DIFF
--- a/src/citric/_compat.py
+++ b/src/citric/_compat.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import warnings
 from functools import wraps
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from types import FunctionType
 
 __all__ = ["FutureVersionWarning", "future", "future_parameter"]
 
@@ -41,9 +44,9 @@ def future(version: str) -> Callable:
     """
     message = _warning_message(version)
 
-    def decorate(fn: Callable) -> Callable:
+    def decorate(fn: FunctionType) -> FunctionType:
         @wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> Callable:
+        def wrapper(*args: Any, **kwargs: Any) -> FunctionType:
             warnings.warn(
                 f"Method {fn.__name__} {''.join(message)}",
                 FutureVersionWarning,


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
