### PR TITLE
test: Remove redundant mock tests already covered by integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ env:
 
 jobs:
   tests:
-    name: "Test ${{ matrix.python-version }} / ${{ matrix.os }}"
+    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -187,7 +187,7 @@ jobs:
         echo "tags=$(cat .github/workflows/resources/tags.json | jq -c .)" >> $GITHUB_OUTPUT
 
   integration:
-    name: "integration ${{ matrix.python-version }} / ${{ matrix.image_tag || matrix.ref }} / ${{ matrix.database }}"
+    name: "Python ${{ matrix.python-version }} / ${{ matrix.image_tag || matrix.ref }} / ${{ matrix.database }}"
     runs-on: ubuntu-24.04
     continue-on-error: true
     needs: [docker_tags]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,7 +274,6 @@ relative_files = true
 exclude_also = [
   '''if (t\.)?TYPE_CHECKING:''',
 ]
-fail_under = 85
 omit = [
   "src/citric/types.py",
 ]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -157,12 +157,6 @@ def server_version(client: citric.Client) -> semver.Version:
     return semver.Version.parse(client.get_server_version())
 
 
-@pytest.fixture(scope="session")
-def database_version(client: citric.Client) -> int:
-    """Get the LimeSurvey database schema version."""
-    return client.get_db_version()
-
-
 @pytest.fixture
 def mailpit(integration_mailpit_url: str) -> MailpitClient:
     """Get the LimeSurvey database schema version."""

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -977,6 +977,7 @@ def test_site_settings(client: citric.Client):
     assert client.get_default_language() == "en"
     assert client.get_default_theme() == "vanilla"
     assert client.get_site_name() == "Citric - Test"
+    assert isinstance(client.get_db_version(), int)
 
 
 @pytest.mark.integration_test

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -263,8 +263,8 @@ def test_group(client: citric.Client):
         key=operator.itemgetter("qid"),
     )
 
-    assert questions[0]["question"] == "<p><strong>First question</p>"
-    assert questions[1]["question"] == "<p><strong>Second question</p>"
+    assert any(q["question"] == "<p><strong>First question</p>" for q in questions)
+    assert any(q["question"] == "<p><strong>Second question</p>" for q in questions)
 
     # Update group properties
     response = client.set_group_properties(created_group, group_order=1)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,18 +37,6 @@ class MockSession(Session):
         """Process a mock RPC call."""
         return {"method": method, "params": [*params]}
 
-    def list_questions(
-        self,
-        survey_id: int,
-        group_id: int | None = None,
-        *args: Any,
-    ) -> list[dict[str, Any]]:
-        """Mock questions."""
-        return [
-            {"title": "Q1", "qid": 1, "gid": group_id or 1, "sid": survey_id},
-            {"title": "Q2", "qid": 2, "gid": group_id or 1, "sid": survey_id},
-        ]
-
     def export_statistics(self, *args: Any) -> bytes:
         """Mock statistics file content."""
         return base64.b64encode(DUMMY_FILE_CONTENTS)
@@ -105,20 +93,6 @@ def test_export_timeline(client: MockClient):
     ) == {
         "2022-01-01": 4,
         "2022-01-02": 2,
-    }
-
-
-def test_map_response_data(client: MockClient):
-    """Test question keys get mapped to LimeSurvey's internal representation."""
-    question_mapping = client._get_question_mapping(1)
-    mapped_responses = client._map_response_keys(
-        {"Q1": "foo", "Q2": "bar", "BAZ": "qux"},
-        question_mapping,
-    )
-    assert mapped_responses == {
-        "1X1X1": "foo",
-        "1X1X2": "bar",
-        "BAZ": "qux",
     }
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,30 +4,16 @@ from __future__ import annotations
 
 import base64
 import datetime
-import sys
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generator
 
 import pytest
 
 from citric.client import Client
-from citric.enums import ImportGroupType, ImportSurveyType, NewSurveyType
 from citric.session import Session
-
-if sys.version_info >= (3, 9):
-    from random import randbytes
-else:
-    from random import getrandbits
-
-    def randbytes(n: int) -> bytes:  # noqa: D103
-        return getrandbits(n * 8).to_bytes(n, "little")
-
 
 if TYPE_CHECKING:
     from _pytest._py.path import LocalPath
-    from faker import Faker
 
-    from citric import types
 
 NEW_GROUP_ID = 300
 NEW_QUESTION_ID = 400
@@ -51,41 +37,6 @@ class MockSession(Session):
         """Process a mock RPC call."""
         return {"method": method, "params": [*params]}
 
-    def import_group(
-        self,
-        survey_id: int,
-        content: str,
-        file_type: str = "lsq",
-        new_name: str | None = None,
-        new_description: str | None = None,
-    ) -> int:
-        """Mock result from importing a group file."""
-        return NEW_GROUP_ID
-
-    def import_question(
-        self,
-        survey_id: int,
-        group_id: int,
-        content: str,
-        file_type: str = "lsq",
-        mandatory: str = "N",
-        new_title: str | None = None,
-        new_text: str | None = None,
-        new_help: str | None = None,
-    ) -> int:
-        """Mock result from importing a question file."""
-        return NEW_QUESTION_ID
-
-    def import_survey(
-        self,
-        content: str,
-        file_type: str = "lss",
-        survey_name: str | None = None,
-        survey_id: int | None = None,
-    ) -> dict[str, Any]:
-        """Mock result from importing a survey file."""
-        return {"content": base64.b64decode(content.encode()), "type": file_type}
-
     def list_questions(
         self,
         survey_id: int,
@@ -98,18 +49,6 @@ class MockSession(Session):
             {"title": "Q2", "qid": 2, "gid": group_id or 1, "sid": survey_id},
         ]
 
-    def add_response(self, *args: Any) -> str:
-        """Mock result from adding a response."""
-        return "1"
-
-    def export_responses(self, *args: Any) -> bytes:
-        """Mock responses file content."""
-        return base64.b64encode(DUMMY_FILE_CONTENTS)
-
-    def export_responses_by_token(self, *args: Any) -> bytes:
-        """Mock responses file content."""
-        return base64.b64encode(DUMMY_FILE_CONTENTS)
-
     def export_statistics(self, *args: Any) -> bytes:
         """Mock statistics file content."""
         return base64.b64encode(DUMMY_FILE_CONTENTS)
@@ -117,49 +56,6 @@ class MockSession(Session):
     def export_timeline(self, *args: Any) -> dict[str, int]:
         """Mock submission timeline."""
         return {"2022-01-01": 4, "2022-01-02": 2}
-
-    def get_site_settings(self, setting_name: str) -> str:
-        """Return the setting value or an empty string."""
-        return self.settings.get(setting_name, "")
-
-    def get_uploaded_files(self, *args: Any) -> dict[str, dict[str, Any]]:
-        """Return uploaded files fake metadata."""
-        return {
-            "1234": {
-                "meta": {
-                    "title": "one",
-                    "comment": "File One",
-                    "name": "file1.txt",
-                    "filename": "1234",
-                    "size": 48.046,
-                    "ext": "txt",
-                    "question": {"title": "G01Q01", "qid": 1},
-                    "index": 0,
-                },
-                "content": base64.b64encode(b"content-1").decode(),
-            },
-            "5678": {
-                "meta": {
-                    "title": "two",
-                    "comment": "File Two",
-                    "size": "581.044921875",
-                    "name": "file2.txt",
-                    "filename": "5678",
-                    "ext": "txt",
-                    "question": {"title": "G01Q01", "qid": 1},
-                    "index": 1,
-                },
-                "content": base64.b64encode(b"content-2").decode(),
-            },
-        }
-
-    def invite_participants(  # noqa: D102
-        self,
-        survey_id: int,
-        token_ids: list[int] | None,
-        strategy: str,
-    ):
-        return "OK"
 
 
 class MockClient(Client):
@@ -195,187 +91,9 @@ def client() -> Generator[Client, None, None]:
         yield client
 
 
-def test_activate_survey(client: MockClient):
-    """Test activate_survey client method."""
-    assert_client_session_call(
-        client,
-        "activate_survey",
-        1,
-        user_activation_settings=None,
-    )
-
-
-def test_activate_tokens(client: MockClient):
-    """Test activate_tokens client method."""
-    assert_client_session_call(client, "activate_tokens", 1, [])
-
-
-def test_add_group(client: MockClient):
-    """Test add_group client method."""
-    assert_client_session_call(
-        client,
-        "add_group",
-        1,
-        "My Group",
-        "A very simple question group",
-    )
-
-
-def test_add_language(client: MockClient):
-    """Test add_language client method."""
-    assert_client_session_call(client, "add_language", 1, "ru")
-
-
-def test_add_survey(client: MockClient):
-    """Test add_survey client method."""
-    assert_client_session_call(
-        client,
-        "add_survey",
-        1,
-        NEW_SURVEY_NAME,
-        "en",
-        NewSurveyType.ALL_ON_ONE_PAGE,
-    )
-
-    with pytest.raises(ValueError, match="'NOT VALID' is not a valid NewSurveyType"):
-        assert_client_session_call(
-            client,
-            "add_survey",
-            1,
-            NEW_SURVEY_NAME,
-            "en",
-            "NOT VALID",
-        )
-
-
-def test_copy_survey(client: MockClient):
-    """Test copy_survey client method."""
-    assert_client_session_call(
-        client,
-        "copy_survey",
-        1,
-        NEW_SURVEY_NAME,
-        destination_survey_id=None,
-    )
-
-
-def test_delete_group(client: MockClient):
-    """Test delete_group client method."""
-    assert_client_session_call(client, "delete_group", 1, 10)
-
-
-def test_delete_language(client: MockClient):
-    """Test delete_language client method."""
-    assert_client_session_call(client, "delete_language", 1, "ru")
-
-
-def test_delete_question(client: MockClient):
-    """Test delete_question client method."""
-    assert_client_session_call(client, "delete_question", 400)
-
-
-def test_delete_response(client: MockClient):
-    """Test delete_response client method."""
-    assert_client_session_call(client, "delete_response", 1, 1)
-
-
-def test_delete_survey(client: MockClient):
-    """Test delete_survey client method."""
-    assert_client_session_call(client, "delete_survey", 1)
-
-
-def test_list_groups(client: MockClient):
-    """Test list_groups client method."""
-    assert_client_session_call(client, "list_groups", 1, "en")
-
-
-def test_list_surveys(client: MockClient):
-    """Test list_surveys client method."""
-    assert_client_session_call(client, "list_surveys", None, survey_group_id=None)
-
-
-def test_list_survey_groups(client: MockClient):
-    """Test list_survey_groups client method."""
-    assert_client_session_call(client, "list_survey_groups", None)
-
-
-def test_get_group_properties(client: MockClient):
-    """Test get_group_properties client method."""
-    assert_client_session_call(
-        client,
-        "get_group_properties",
-        123,
-        settings=["gid"],
-        language="es",
-    )
-
-
-def test_get_language_properties(client: MockClient):
-    """Test get_language_properties client method."""
-    assert_client_session_call(
-        client,
-        "get_language_properties",
-        123,
-        settings=["surveyls_email_register_subj"],
-        language="es",
-    )
-
-
-def test_get_question_properties(client: MockClient):
-    """Test get_question_properties client method."""
-    assert_client_session_call(
-        client,
-        "get_question_properties",
-        123,
-        settings=["type"],
-        language="es",
-    )
-
-
-def test_get_response_ids(client: MockClient):
-    """Test get stored response IDs from a survey."""
-    assert_client_session_call(client, "get_response_ids", 1, "TOKEN")
-
-
 def test_get_summary(client: MockClient):
     """Test get_summary client method."""
     assert_client_session_call(client, "get_summary", 1)
-
-
-def test_get_survey_properties(client: MockClient):
-    """Test get_survey_properties client method."""
-    assert_client_session_call(client, "get_survey_properties", 1, None)
-
-
-def test_list_users(client: MockClient):
-    """Test list_users client method."""
-    assert_client_session_call(client, "list_users", user_id=None, username=None)
-
-
-def test_list_questions(client: MockClient):
-    """Test list_questions client method."""
-    assert_client_session_call(client, "list_questions", 1)
-
-
-def test_add_participants(client: MockClient, faker: Faker):
-    """Test add_participants client method."""
-    participants = [
-        {"firstname": faker.first_name()},
-        {"firstname": faker.first_name()},
-    ]
-    assert_client_session_call(
-        client,
-        "add_participants",
-        1,
-        participant_data=participants,
-        create_tokens=True,
-    )
-
-
-def test_delete_participants(client: MockClient):
-    """Test delete_participants client method."""
-    participants = [1, 2, 3]
-    assert_client_session_call(client, "delete_participants", 1, participants)
 
 
 def test_export_timeline(client: MockClient):
@@ -388,97 +106,6 @@ def test_export_timeline(client: MockClient):
         "2022-01-01": 4,
         "2022-01-02": 2,
     }
-
-
-def test_participant_properties(client: MockClient):
-    """Test get_participant_properties client method."""
-    assert_client_session_call(client, "get_participant_properties", 1, 1, None)
-
-
-def test_list_participants(client: MockClient):
-    """Test get_participant_properties client method."""
-    assert_client_session_call(
-        client,
-        "list_participants",
-        1,
-        start=0,
-        limit=10,
-        unused=False,
-        attributes=False,
-        conditions={},
-    )
-
-
-def test_get_default_theme(client: MockClient):
-    """Test get site default theme."""
-    assert client.get_default_theme() == "mock-theme"
-
-
-def test_get_site_name(client: MockClient):
-    """Test get site name."""
-    assert client.get_site_name() == "mock-site"
-
-
-def test_get_default_language(client: MockClient):
-    """Test get site default language."""
-    assert client.get_default_language() == "mock-lang"
-
-
-def test_get_available_languages(client: MockClient):
-    """Test get site available languages."""
-    assert client.get_available_languages() == ["en", "fr", "es"]
-
-
-def test_get_server_version(client: MockClient):
-    """Test get server version."""
-    assert client.get_server_version() == "6.0.0"
-
-
-def test_get_database_version(client: MockClient):
-    """Test get database version."""
-    assert client.get_db_version() == 321
-
-
-def test_import_group(client: MockClient, tmp_path: Path):
-    """Test import_group client method."""
-    random_bytes = randbytes(100)
-
-    filepath = Path(tmp_path) / "group.lsq"
-
-    with Path(filepath).open("wb") as f:
-        f.write(random_bytes)
-
-    with Path(filepath).open("rb") as f:
-        assert client.import_group(f, 100, ImportGroupType.LSG) == NEW_GROUP_ID
-
-
-def test_import_question(client: MockClient, tmp_path: Path):
-    """Test import_question client method."""
-    random_bytes = randbytes(100)
-
-    filepath = Path(tmp_path) / "question.lsq"
-
-    with Path(filepath).open("wb") as f:
-        f.write(random_bytes)
-
-    with Path(filepath).open("rb") as f:
-        assert client.import_question(f, 100, 1) == NEW_QUESTION_ID
-
-
-def test_import_survey(client: MockClient, tmp_path: Path):
-    """Test import_survey client method."""
-    random_bytes = randbytes(100)
-
-    filepath = Path(tmp_path) / "survey.lss"
-
-    with Path(filepath).open("wb") as f:
-        f.write(random_bytes)
-
-    with Path(filepath).open("rb") as f:
-        assert client.import_survey(f) == {
-            "content": random_bytes,
-            "type": ImportSurveyType.LSS,
-        }
 
 
 def test_map_response_data(client: MockClient):
@@ -495,98 +122,11 @@ def test_map_response_data(client: MockClient):
     }
 
 
-def test_add_responses(client: MockClient):
-    """Test add_responses client method."""
-    assert client.add_responses(1, [{"Q1": "foo"}, {"Q1": "bar"}]) == [1, 1]
-
-
-def test_save_responses(client: MockClient, tmpdir: LocalPath):
-    """Test export_responses and export_responses_by_token client methods."""
-    filename = tmpdir / "responses.csv"
-    client.save_responses(filename, 1, file_format="csv")
-    assert filename.read_binary() == DUMMY_FILE_CONTENTS
-
-    filename_token = tmpdir / "responses_token.csv"
-    client.save_responses(filename_token, 1, token="123abc", file_format="csv")
-    assert filename_token.read_binary() == DUMMY_FILE_CONTENTS
-
-
 def test_save_statistics(client: MockClient, tmpdir: LocalPath):
     """Test save_statistics and export_responses_by_token client methods."""
     filename = tmpdir / "example.html"
     client.save_statistics(filename, 1, file_format="html")
     assert filename.read_binary() == DUMMY_FILE_CONTENTS
-
-
-def test_download_files(client: MockClient, tmp_path: Path):
-    """Test files are downloaded correctly."""
-    expected = {tmp_path / "1234", tmp_path / "5678"}
-    paths = client.download_files(tmp_path, 1, "TOKEN")
-
-    assert set(paths) == expected
-    assert paths[0].read_text() == "content-1"
-    assert paths[1].read_text() == "content-2"
-
-
-def test_set_group_properties(client: MockClient):
-    """Test set_group_properties client method."""
-    props: types.GroupProperties = {"group_name": "foo"}
-    assert client.set_group_properties(
-        1,
-        **props,
-    ) == client.session.set_group_properties(1, props)
-
-
-def test_set_language_properties(client: MockClient):
-    """Test set_language_properties client method."""
-    props: types.LanguageProperties = {"surveyls_title": "foo"}
-    assert client.set_language_properties(
-        1,
-        language="en",
-        **props,
-    ) == client.session.set_language_properties(1, props, "en")
-
-
-def test_set_participant_properties(client: MockClient):
-    """Test set_participant_properties client method."""
-    token_data = {"name": "Bob"}
-    assert client.set_participant_properties(
-        1,
-        123,
-        **token_data,
-    ) == client.session.set_participant_properties(1, 123, token_data)
-
-
-def test_set_question_properties(client: MockClient):
-    """Test set_question_properties client method."""
-    props: types.QuestionProperties = {"title": "foo", "mandatory": "Y", "type": "text"}
-    assert client.set_question_properties(
-        1,
-        language="en",
-        **props,
-    ) == client.session.set_question_properties(1, props, "en")
-
-
-def test_set_quota_properties(client: MockClient):
-    """Test set_quota_properties client method."""
-    props: types.QuotaProperties = {"name": "foo", "qlimit": 150, "action": 1}
-    assert client.set_quota_properties(
-        1,
-        **props,
-    ) == client.session.set_quota_properties(1, props)
-
-
-def test_set_survey_properties(client: MockClient, faker: Faker):
-    """Test set_survey_properties client method."""
-    props: types.SurveyProperties = {
-        "allowsave": "Y",
-        "ipanonymize": "Y",
-        "emailnotificationto": faker.email(),
-    }
-    assert client.set_survey_properties(
-        1,
-        **props,
-    ) == client.session.set_survey_properties(1, props)
 
 
 def test_invite_participants_unknown_status(client: MockClient):


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

Move everything I can to run in an integration test. Needs https://github.com/edgarrmondragon/citric/pull/1351 for 100% test coverage.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
