### PR TITLE
fix: Fixed typo `ExporAdditionalOptions` -> `ExportAdditionalOptions`

### DIFF
--- a/.changes/unreleased/Changed-20250514-204743.yaml
+++ b/.changes/unreleased/Changed-20250514-204743.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Fixed typo `ExporAdditionalOptions` -> `ExportAdditionalOptions`
+time: 2025-05-14T20:47:43.36295-06:00
+custom:
+    Issue: "1372"

--- a/.changes/unreleased/Packaging-20250514-204923.yaml
+++ b/.changes/unreleased/Packaging-20250514-204923.yaml
@@ -1,0 +1,5 @@
+kind: Packaging
+body: Removed license trove classifier and rely on PEP 639 (
+time: 2025-05-14T20:49:23.919247-06:00
+custom:
+    Issue: "1371"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -624,7 +624,7 @@ class Client:  # noqa: PLR0904
         from_response_id: int | None = None,
         to_response_id: int | None = None,
         fields: Sequence[str] | None = None,
-        additional_options: types.ExporAdditionalOptions | None = None,
+        additional_options: types.ExportAdditionalOptions | None = None,
     ) -> bytes:
         """Export responses to a file-like object.
 
@@ -700,7 +700,7 @@ class Client:  # noqa: PLR0904
         from_response_id: int | None = None,
         to_response_id: int | None = None,
         fields: Sequence[str] | None = None,
-        additional_options: types.ExporAdditionalOptions | None = None,
+        additional_options: types.ExportAdditionalOptions | None = None,
     ) -> int:
         """Save responses to a file.
 

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 __all__ = [
     "CPDBParticipantImportResult",
     "EncodedFile",
-    "ExporAdditionalOptions",
+    "ExportAdditionalOptions",
     "FileMetadata",
     "FileUploadResult",
     "GroupProperties",
@@ -666,7 +666,7 @@ class SurveyUserActivationSettings(TypedDict, total=False):
     """Whether the survey saves response timings."""
 
 
-class ExporAdditionalOptions(TypedDict, total=False):
+class ExportAdditionalOptions(TypedDict, total=False):
     """Export formatting options."""
 
     convertY: bool


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
