### PR TITLE
typing: Annotate the participant fields in the response from `list_participants`

### DIFF
--- a/.changes/unreleased/Typing-20250515-142309.yaml
+++ b/.changes/unreleased/Typing-20250515-142309.yaml
@@ -1,0 +1,5 @@
+kind: Typing
+body: Annotate the participant fields in the response from `list_participants`
+time: 2025-05-15T14:23:09.677699-06:00
+custom:
+    Issue: "1374"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1389,7 +1389,7 @@ class Client:  # noqa: PLR0904
         unused: bool = False,
         attributes: Sequence[str] | bool = False,
         conditions: Mapping[str, Any] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[types.ParticipantListElement]:
         """Get participants in a survey.
 
         Calls :rpc_method:`list_participants`.

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -29,6 +29,8 @@ __all__ = [
     "GroupProperties",
     "LanguageProperties",
     "OperationStatus",
+    "ParticipantInfo",
+    "ParticipantListElement",
     "Permission",
     "QuestionProperties",
     "QuestionReference",

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -901,7 +901,7 @@ class ParticipantListElement(TypedDict, total=False):
     token: Required[str]
     """The participant access code."""
 
-    participant_info: ParticipantInfo
+    participant_info: Required[ParticipantInfo]
     """The participant info."""
 
     emailstatus: str

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -13,6 +13,11 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import TypeAlias
 
+    if sys.version_info >= (3, 11):
+        from typing import Required
+    else:
+        from typing_extensions import Required
+
     from citric import enums
 
 __all__ = [
@@ -870,3 +875,59 @@ class SurveySummary(TypedDict, total=False):
 
     full_responses: int
     """The number of full responses."""
+
+
+class ParticipantInfo(TypedDict):
+    """Participant info."""
+
+    firstname: str
+    """The participant first name."""
+
+    lastname: str
+    """The participant last name."""
+
+    email: str
+    """The participant email."""
+
+
+class ParticipantListElement(TypedDict, total=False):
+    """Participant list element."""
+
+    tid: Required[int]
+    """The participant access code ID."""
+
+    token: Required[str]
+    """The participant access code."""
+
+    participant_info: ParticipantInfo
+    """The participant info."""
+
+    emailstatus: str
+    """The participant email status."""
+
+    language: str
+    """The participant language."""
+
+    blacklisted: YesNo
+    """Whether the participant is blacklisted."""
+
+    sent: YesNo
+    """Whether the participant invitation was sent."""
+
+    remindersent: YesNo
+    """Whether the participant reminder was sent."""
+
+    remindercount: int
+    """The total number of reminders sent."""
+
+    completed: YesNo
+    """Whether the participant completed the survey."""
+
+    usesleft: int
+    """How many uses left to fill questionnaire for this participant."""
+
+    validfrom: str
+    """Start date of the participant access code."""
+
+    validuntil: str
+    """End date of the participant access code."""

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -641,13 +641,13 @@ def test_participants(
     assert len(participants_list) == 2
 
     # Check added participant properties
-    for p, d in zip(participants_list, participants[:2]):
-        with subtests.test(msg="test new participants properties", token=p["tid"]):
-            assert p["participant_info"]["email"] == d["email"]
-            assert p["participant_info"]["firstname"] == d["firstname"]
-            assert p["participant_info"]["lastname"] == d["lastname"]
-            assert p["attribute_1"] == d["attribute_1"]
-            assert p["attribute_2"] == d["attribute_2"]
+    for ple, d in zip(participants_list, participants[:2]):
+        with subtests.test(msg="test new participants properties", token=ple["tid"]):
+            assert ple["participant_info"]["email"] == d["email"]
+            assert ple["participant_info"]["firstname"] == d["firstname"]
+            assert ple["participant_info"]["lastname"] == d["lastname"]
+            assert ple["attribute_1"] == d["attribute_1"]  # type: ignore[typeddict-item]
+            assert ple["attribute_2"] == d["attribute_2"]  # type: ignore[typeddict-item]
 
     # Get participant properties
     for p, d in zip(added, participants[:2]):


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
