### PR TITLE
refactor: Remove `TYPE_CHECKING` guards in modules that define types

### DIFF
--- a/.changes/unreleased/Packaging-20250515-164357.yaml
+++ b/.changes/unreleased/Packaging-20250515-164357.yaml
@@ -1,0 +1,5 @@
+kind: Packaging
+body: Make `typing-extensions` a runtime dependency
+time: 2025-05-15T16:43:57.026621-06:00
+custom:
+    Issue: "1375"

--- a/.changes/unreleased/Typing-20250515-163003.yaml
+++ b/.changes/unreleased/Typing-20250515-163003.yaml
@@ -1,5 +1,5 @@
 kind: Typing
-body: 'refactor: Remove `TYPE_CHECKING` guards in modules that define types'
+body: Remove `TYPE_CHECKING` guards in modules that define types
 time: 2025-05-15T16:30:03.054978-06:00
 custom:
     Issue: "1375"

--- a/.changes/unreleased/Typing-20250515-163003.yaml
+++ b/.changes/unreleased/Typing-20250515-163003.yaml
@@ -1,0 +1,5 @@
+kind: Typing
+body: 'refactor: Remove `TYPE_CHECKING` guards in modules that define types'
+time: 2025-05-15T16:30:03.054978-06:00
+custom:
+    Issue: "1375"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 ]
 dependencies = [
   "requests>=2.25.1",
+  "typing-extensions>=4.6; python_version<'3.12'",
 ]
 urls.Documentation = "https://citric.readthedocs.io"
 urls.Funding = "https://github.com/sponsors/edgarrmondragon"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,9 @@ lint.per-file-ignores."docs/notebooks/*" = [
 lint.per-file-ignores."src/*" = [
   "PD", # pandas-vet
 ]
+lint.per-file-ignores."src/citric/types.py" = [
+  "TC", # type-checking
+]
 lint.per-file-ignores."tests/*" = [
   "ANN201",  # missing-return-type-undocumented-public-function
   "ARG00",   # unused-method-argument

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -2,23 +2,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+import io
+import sys
+from typing import Any, Literal, TypedDict
 
-if TYPE_CHECKING:
-    import io
-    import sys
+from citric import enums
 
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
-    if sys.version_info >= (3, 11):
-        from typing import Required
-    else:
-        from typing_extensions import Required
-
-    from citric import enums
+if sys.version_info >= (3, 11):
+    from typing import Required
+else:
+    from typing_extensions import Required
 
 __all__ = [
     "CPDBParticipantImportResult",

--- a/uv.lock
+++ b/uv.lock
@@ -245,6 +245,7 @@ version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -358,7 +359,10 @@ typing = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.25.1" }]
+requires-dist = [
+    { name = "requests", specifier = ">=2.25.1" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
