### PR TITLE
test: Handle broken `/rest/v1/survey-detail/{survey_id}` in LimeSurvey 6.15+

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -83,6 +83,7 @@ def integration(session: nox.Session) -> None:
             "--integration",
             "-m",
             "integration_test",
+            *session.posargs,
             env={"COVERAGE_CORE": "sysmon"},
         )
     finally:

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -83,11 +83,27 @@ def test_get_survey_details(rest_client: RESTClient, survey_id: int) -> None:
 
 @pytest.mark.integration_test
 def test_patch_survey_details(
+    request: pytest.FixtureRequest,
     server_version: semver.Version,
     rest_client: RESTClient,
     survey_id: int,
 ) -> None:
     """Test getting surveys."""
+    if server_version >= (6, 15, 0):
+        # TODO(edgarrmondragon): Investigate this
+        # https://github.com/edgarrmondragon/citric/issues/1420
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    "The REST API seems to be broken in LimeSurvey >= 6.15.0 "
+                    "and updating survey details fails with "
+                    "'Failed saving general settings for survey'. "
+                    f"The current server version is {server_version}."
+                ),
+                strict=True,
+            )
+        )
+
     original = rest_client.get_survey_details(survey_id=survey_id)
     anonymized = original["anonymized"]
     token_length = original["tokenLength"]


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
