### PR TITLE
docs: Update code sample for custom session attributes to set custom headers

### DIFF
--- a/.changes/unreleased/Documentation-20250708-214601.yaml
+++ b/.changes/unreleased/Documentation-20250708-214601.yaml
@@ -2,4 +2,4 @@ kind: Documentation
 body: Update code sample for custom session attributes to set custom headers
 time: 2025-07-08T21:46:01.664503-06:00
 custom:
-    Issue: "9999"
+    Issue: "1423"

--- a/.changes/unreleased/Documentation-20250708-214601.yaml
+++ b/.changes/unreleased/Documentation-20250708-214601.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Update code sample for custom session attributes to set custom headers
+time: 2025-07-08T21:46:01.664503-06:00
+custom:
+    Issue: "9999"

--- a/code_samples/requests_session_attributes.py
+++ b/code_samples/requests_session_attributes.py
@@ -8,9 +8,9 @@ from citric import Client
 
 session = requests.Session()
 
-# Set to False to accept any TLS certificate presented by the server
-# https://requests.readthedocs.io/en/latest/api/#requests.Session.verify
-session.verify = False
+# Set custom headers to be sent on each request
+# https://requests.readthedocs.io/en/latest/api/#requests.Session.headers
+session.headers["My-Custom-Header"] = "My-Custom-Value"
 
 client = Client(
     "https://mylimeserver.com/index.php/admin/remotecontrol",


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
