### PR TITLE
test: Fix the expected error message when a survey participant list has not been added but the user tries to list participants

### DIFF
--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -595,11 +595,21 @@ def test_activate_survey_with_settings(
 
 
 @pytest.mark.integration_test
-def test_activate_tokens(client: citric.Client, survey_id: int):
+def test_activate_tokens(
+    client: citric.Client,
+    survey_id: int,
+    server_version: semver.VersionInfo,
+):
     """Test whether the participants table gets activated."""
     client.activate_survey(survey_id)
 
-    with pytest.raises(LimeSurveyStatusError, match="No survey participants table"):
+    # LimeSurvey 6.15.4+ changed the error message
+    if server_version >= (6, 15, 4):
+        expected_pattern = "Error: No survey participant list"
+    else:
+        expected_pattern = "No survey participants table"
+
+    with pytest.raises(LimeSurveyStatusError, match=expected_pattern):
         client.list_participants(survey_id)
 
     client.activate_tokens(survey_id, [1, 2, 3, 4, 5])


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

CI is green for `6-apache`.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
