### PR TITLE
packaging: Dropped support for Python 3.9

### DIFF
--- a/.changes/unreleased/Packaging-20250910-210856.yaml
+++ b/.changes/unreleased/Packaging-20250910-210856.yaml
@@ -1,0 +1,5 @@
+kind: Packaging
+body: Dropped support for Python 3.9
+time: 2025-09-10T21:08:56.618511-06:00
+custom:
+    Issue: "1503"

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -28,8 +28,7 @@ body:
         - "3.12"
         - "3.11"
         - "3.10"
-        - "3.9"
-        - "3.8 or earlier"
+        - "3.9 or earlier"
         - "NA"
     validations:
       required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,9 +77,6 @@ jobs:
         - python-version: "3.10"
           os: ubuntu-24.04
 
-        - python-version: "3.9"
-          os: ubuntu-24.04
-
         - python-version: "3.15"
           os: ubuntu-24.04
 
@@ -199,10 +196,6 @@ jobs:
         image_tag: ${{ fromJson(needs.docker_tags.outputs.tags) }}
         include:
         # Test on other Python versions
-        - python-version: "3.9"
-          image_tag: "6-apache"
-          database: postgres
-
         - python-version: "3.10"
           image_tag: "6-apache"
           database: postgres

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -7,8 +7,4 @@ documentation site and watch the repo for changes:
 nox -rs docs-serve
 ```
 
-```{note}
-Python 3.9+ is required to build the documentation.
-```
-
 [environment]: /contributing/environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ maintainers = [
 authors = [
   { name = "Edgar Ramírez-Mondragón", email = "edgarrm358@gmail.com" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
@@ -29,7 +29,6 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: System Administrators",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -63,12 +62,11 @@ test = [
   "beautifulsoup4>=4.13.4",
   "coverage[toml]>=7.4.2",
   "faker>=19",
-  "pytest>=8",
+  "pytest>=9",
   "pytest-docker>=3.1.1",
   "pytest-github-actions-annotate-failures>=0.1.7",
   "pytest-httpserver>=1.0.8",
   "pytest-randomly>=3.15",
-  "pytest-subtests>=0.11; python_version<'3.10'",
   "python-dotenv>=1",
   "semver>=3.0.1",
   "tinydb>=4.8",
@@ -251,7 +249,7 @@ DEP004 = [
 [tool.pyproject-fmt]
 max_supported_python = "3.15"
 
-[tool.pytest.ini_options]
+[tool.pytest]
 addopts = [
   "--durations=5",
   "-ra",              # show extra test summary info for all except passed
@@ -268,7 +266,7 @@ markers = [
   "integration_test: Integration and end-to-end tests",
   "xfail_mysql: Mark a test as expected to fail on MySQL",
 ]
-minversion = "8"
+minversion = "9"
 testpaths = [
   "tests",
 ]

--- a/scripts/docker_tags.py
+++ b/scripts/docker_tags.py
@@ -2,7 +2,7 @@
 
 # /// script
 # dependencies = ["requests", "requests-cache"]
-# requires-python = ">=3.9"
+# requires-python = ">=3.10"
 # ///
 
 """Get all tags from the Docker Hub."""

--- a/src/citric/method.py
+++ b/src/citric/method.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = ["Method"]
 

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 
 import io
 import sys
-from typing import Any, Literal, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from citric import enums
-
-if sys.version_info >= (3, 10):
-    from typing import TypeAlias
-else:
-    from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 11):
     from typing import Required

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -24,19 +24,10 @@ from citric.exceptions import LimeSurveyApiError, LimeSurveyStatusError
 from citric.objects import Participant
 
 if TYPE_CHECKING:
-    import sys
-
     from faker import Faker
 
     from citric.types import QuestionsListElement
     from tests.fixtures import MailpitClient
-
-    if sys.version_info >= (3, 10):
-        from pytest import Subtests as SubtestsFixture  # noqa: PT013
-    else:
-        from pytest_subtests import (  # ty: ignore[unresolved-import]
-            SubTests as SubtestsFixture,
-        )
 
 NEW_SURVEY_NAME = "New Survey"
 
@@ -73,7 +64,7 @@ def participants(faker: Faker) -> list[dict[str, Any]]:
 
 
 @pytest.mark.integration_test
-def test_fieldmap(client: citric.Client, survey_id: int, subtests: SubtestsFixture):
+def test_fieldmap(client: citric.Client, survey_id: int, subtests: pytest.Subtests):
     """Test fieldmap."""
     fieldmap = client.get_fieldmap(survey_id)
     for key, value in fieldmap.items():
@@ -87,7 +78,7 @@ def test_fieldmap(client: citric.Client, survey_id: int, subtests: SubtestsFixtu
 
 
 @pytest.mark.integration_test
-def test_language(client: citric.Client, survey_id: int, subtests: SubtestsFixture):
+def test_language(client: citric.Client, survey_id: int, subtests: pytest.Subtests):
     """Test language methods."""
     # Add a new language
     assert client.add_language(survey_id, "es")["status"] == "OK"
@@ -133,7 +124,7 @@ def test_language(client: citric.Client, survey_id: int, subtests: SubtestsFixtu
 def test_survey(
     client: citric.Client,
     server_version: semver.VersionInfo,
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test survey methods."""
     # Try to get a survey that doesn't exist
@@ -187,7 +178,7 @@ def test_survey(
 
 
 @pytest.mark.integration_test
-def test_import_survey(client: citric.Client, subtests: SubtestsFixture):
+def test_import_survey(client: citric.Client, subtests: pytest.Subtests):
     """Test importing a survey with a custom ID and name."""
     survey_id = random.randint(10000, 20000)  # noqa: S311
     with Path("./examples/survey.lss").open("rb") as f:
@@ -425,7 +416,7 @@ def test_quota(
     client: citric.Client,
     server_version: semver.VersionInfo,
     survey_id: int,
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test quota methods."""
     request.applymarker(
@@ -631,7 +622,7 @@ def test_participants(
     client: citric.Client,
     survey_id: int,
     participants: list[dict[str, str]],
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test participants methods."""
     client.activate_survey(survey_id)
@@ -643,7 +634,7 @@ def test_participants(
         participant_data=participants,
         create_tokens=False,
     )
-    for p, d in zip(added, participants):
+    for p, d in zip(added, participants, strict=False):
         with subtests.test(msg="test new participants properties", token=d["token"]):
             assert p["email"] == d["email"]
             assert p["firstname"] == d["firstname"]
@@ -660,7 +651,7 @@ def test_participants(
     assert len(participants_list) == 2
 
     # Check added participant properties
-    for ple, d in zip(participants_list, participants[:2]):
+    for ple, d in zip(participants_list, participants[:2], strict=False):
         with subtests.test(msg="test new participants properties", token=ple["tid"]):
             assert ple["participant_info"]["email"] == d["email"]
             assert ple["participant_info"]["firstname"] == d["firstname"]
@@ -669,7 +660,7 @@ def test_participants(
             assert ple["attribute_2"] == d["attribute_2"]  # type: ignore[typeddict-item]
 
     # Get participant properties
-    for p, d in zip(added, participants[:2]):
+    for p, d in zip(added, participants[:2], strict=False):
         with subtests.test(msg="test updated participants properties", token=p["tid"]):
             properties = client.get_participant_properties(survey_id, p["tid"])
             assert properties["email"] == d["email"]
@@ -770,7 +761,7 @@ def test_responses(
     survey_id: int,
     responses: list[dict],
     tmp_path: Path,
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test adding and exporting responses."""
     client.activate_survey(survey_id)
@@ -880,7 +871,7 @@ def test_summary(
     survey_id: int,
     participants: list[dict],
     responses: list[dict],
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test get_summary client method."""
     with (
@@ -1210,7 +1201,7 @@ def test_mail_registered_participants(
     survey_id: int,
     participants: list[dict[str, str]],
     mailpit: MailpitClient,
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test mail_registered_participants."""
     client.activate_survey(survey_id)
@@ -1254,7 +1245,7 @@ def test_remind_participants(
     survey_id: int,
     participants: list[dict[str, str]],
     mailpit: MailpitClient,
-    subtests: SubtestsFixture,
+    subtests: pytest.Subtests,
 ):
     """Test remind_participants."""
     client.activate_survey(survey_id)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import pytest
 import tinydb
@@ -15,16 +15,11 @@ from werkzeug.wrappers import Response
 from citric.rest import RESTClient
 
 if TYPE_CHECKING:
-    import sys
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
+    from typing import TypeAlias
 
     from pytest_httpserver import HTTPServer
     from werkzeug.wrappers import Request
-
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
     APIHandler: TypeAlias = Callable[[Request], Response]
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Reached EOL on October 2025.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
