### PR TITLE
fix: Use `enum.StrEnum` to get enum members with the correct `repr()` value

### DIFF
--- a/.changes/unreleased/Refactored-20251015-102033.yaml
+++ b/.changes/unreleased/Refactored-20251015-102033.yaml
@@ -1,0 +1,5 @@
+kind: Refactored
+body: Use `enum.StrEnum` to get enum members with the correct `repr()` value
+time: 2025-10-15T10:20:33.903411-06:00
+custom:
+    Issue: "1547"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
+  "backports-strenum>=1.3.1; python_version<'3.11'",
   "requests>=2.25.1",
   "typing-extensions>=4.6; python_version<'3.12'",
 ]
@@ -83,6 +84,7 @@ docs = [
   "sphinx-notfound-page>=1",
 ]
 typing = [
+  "backports-strenum",
   "mypy>=1.9",
   "sphinx",
   "ty>=0.0.1a15",
@@ -225,6 +227,7 @@ pep621_dev_dependency_groups = [
 ]
 
 [tool.deptry.package_module_name_map]
+backports-strenum = [ "backports", "strenum" ]
 types-requests = "requests"
 typing-extensions = "typing_extensions"
 

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -3,6 +3,12 @@
 from __future__ import annotations
 
 import enum
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 __all__ = [
     "EmailSendStrategy",
@@ -14,25 +20,20 @@ __all__ = [
     "ResponseType",
     "ResponsesExportFormat",
     "StatisticsExportFormat",
-    "StringEnum",
     "SurveyCompletionStatus",
     "TimelineAggregationPeriod",
     "UserStatus",
 ]
 
 
-class StringEnum(str, enum.Enum):
-    """Enum with string values."""
-
-
-class ImportGroupType(StringEnum):
+class ImportGroupType(StrEnum):
     """Group file type."""
 
     LSG = "lsg"
     CSV = "csv"
 
 
-class ImportSurveyType(StringEnum):
+class ImportSurveyType(StrEnum):
     """Survey file type."""
 
     LSS = "lss"
@@ -41,7 +42,7 @@ class ImportSurveyType(StringEnum):
     LSA = "lsa"
 
 
-class NewSurveyType(StringEnum):
+class NewSurveyType(StrEnum):
     """New survey type."""
 
     ALL_ON_ONE_PAGE = "A"
@@ -49,7 +50,7 @@ class NewSurveyType(StringEnum):
     SINGLE_QUESTIONS = "S"
 
 
-class StatisticsExportFormat(StringEnum):
+class StatisticsExportFormat(StrEnum):
     """Statistics export type."""
 
     PDF = "pdf"
@@ -57,7 +58,7 @@ class StatisticsExportFormat(StringEnum):
     HTML = "html"
 
 
-class ResponsesExportFormat(StringEnum):
+class ResponsesExportFormat(StrEnum):
     """Responses export type."""
 
     PDF = "pdf"
@@ -67,7 +68,7 @@ class ResponsesExportFormat(StringEnum):
     JSON = "json"
 
 
-class SurveyCompletionStatus(StringEnum):
+class SurveyCompletionStatus(StrEnum):
     """Survey completion status values."""
 
     #: Include only incomplete answers
@@ -80,7 +81,7 @@ class SurveyCompletionStatus(StringEnum):
     ALL = "all"
 
 
-class HeadingType(StringEnum):
+class HeadingType(StrEnum):
     """Types of heading in responses export."""
 
     CODE = "code"
@@ -88,21 +89,21 @@ class HeadingType(StringEnum):
     ABBREVIATED = "abbreviated"
 
 
-class ResponseType(StringEnum):
+class ResponseType(StrEnum):
     """Types of responses in export."""
 
     LONG = "long"
     SHORT = "short"
 
 
-class TimelineAggregationPeriod(StringEnum):
+class TimelineAggregationPeriod(StrEnum):
     """Timeline aggregation level."""
 
     HOUR = "hour"
     DAY = "day"
 
 
-class QuotaAction(StringEnum):
+class QuotaAction(StrEnum):
     """Quota action."""
 
     TERMINATE = "terminate"

--- a/uv.lock
+++ b/uv.lock
@@ -108,6 +108,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-strenum"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/c7/2ed54c32fed313591ffb21edbd48db71e68827d43a61938e5a0bc2b6ec91/backports_strenum-1.3.1.tar.gz", hash = "sha256:77c52407342898497714f0596e86188bb7084f89063226f4ba66863482f42414", size = 7257, upload-time = "2023-12-09T14:36:40.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/50/56cf20e2ee5127b603b81d5a69580a1a325083e2b921aa8f067da83927c0/backports_strenum-1.3.1-py3-none-any.whl", hash = "sha256:cdcfe36dc897e2615dc793b7d3097f54d359918fc448754a517e6f23044ccf83", size = 8304, upload-time = "2023-12-09T14:36:39.905Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -252,6 +261,7 @@ name = "citric"
 version = "2.0.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "requests" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
@@ -259,6 +269,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "autodocsumm" },
+    { name = "backports-strenum" },
     { name = "beautifulsoup4" },
     { name = "colorama" },
     { name = "coverage", extra = ["toml"] },
@@ -325,6 +336,7 @@ test = [
     { name = "xdoctest", extra = ["colors"] },
 ]
 typing = [
+    { name = "backports-strenum" },
     { name = "beautifulsoup4" },
     { name = "coverage", extra = ["toml"] },
     { name = "faker" },
@@ -350,6 +362,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "backports-strenum", marker = "python_full_version < '3.11'", specifier = ">=1.3.1" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.6" },
 ]
@@ -357,6 +370,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "autodocsumm", specifier = ">=0.2.5" },
+    { name = "backports-strenum" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.4.2" },
@@ -417,6 +431,7 @@ test = [
     { name = "xdoctest", extras = ["colors"], specifier = ">=1.1.1" },
 ]
 typing = [
+    { name = "backports-strenum" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.4.2" },
     { name = "faker", specifier = ">=19" },
@@ -677,7 +692,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [ ] My pull request has a descriptive title.
- [ ] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
