### PR TITLE
feat: Make the `RESTClient` public

### DIFF
--- a/.changes/unreleased/Added-20251017-004142.yaml
+++ b/.changes/unreleased/Added-20251017-004142.yaml
@@ -2,4 +2,4 @@ kind: Added
 body: Support updating answers using the REST API
 time: 2025-10-17T00:41:42.568962-06:00
 custom:
-    Issue: "1540"
+    Issue: "1548"

--- a/.changes/unreleased/Added-20251017-011917.yaml
+++ b/.changes/unreleased/Added-20251017-011917.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Made the `RESTClient` public
+time: 2025-10-17T01:19:17.057568-06:00
+custom:
+    Issue: "1549"

--- a/code_samples/update_question_answer_rest.py
+++ b/code_samples/update_question_answer_rest.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 # start example
-from citric._rest import RESTClient  # noqa: PLC2701
+from citric.rest import RESTClient
 
 # Create REST client
 client = RESTClient(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,6 @@ autoapi_options = [
     "show-module-summary",
     "special-members",
     "imported-members",
-    "private-members",
 ]
 autoapi_root = "_api"
 
@@ -181,7 +180,7 @@ def skip_member_filter(
     Returns:
         Whether to skip the member.
     """
-    if name == "citric.rest.client":
+    if name in {"citric.client", "citric.rest"}:
         skip = True
     return skip
 

--- a/docs/rest_coverage.md
+++ b/docs/rest_coverage.md
@@ -2,8 +2,8 @@
 
 | Name | Implemented |
 | :----------------------------------------- | :-------------------------------------------------- |
-| `POST /rest/v1/session` | [Yes](citric._rest.RESTClient.authenticate) |
-| `DELETE /rest/v1/session` | [Yes](citric._rest.RESTClient.close) |
-| `GET /rest/v1/survey` | [Yes](citric._rest.RESTClient.get_surveys) |
-| `GET /rest/v1/survey-detail/{survey_id}` | [Yes](citric._rest.RESTClient.get_survey_details) |
-| `PATCH /rest/v1/survey-detail/{survey_id}` | [Yes](citric._rest.RESTClient.update_survey_details) |
+| `POST /rest/v1/session` | [Yes](citric.RESTClient.authenticate) |
+| `DELETE /rest/v1/session` | [Yes](citric.RESTClient.close) |
+| `GET /rest/v1/survey` | [Yes](citric.RESTClient.get_surveys) |
+| `GET /rest/v1/survey-detail/{survey_id}` | [Yes](citric.RESTClient.get_survey_details) |
+| `PATCH /rest/v1/survey-detail/{survey_id}` | [Yes](citric.RESTClient.patch_survey) |

--- a/src/citric/__init__.py
+++ b/src/citric/__init__.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from importlib import metadata
 
 from citric.client import Client
+from citric.rest import RESTClient
 
 __version__ = metadata.version("citric")
 """Package version"""
 
 del annotations, metadata
 
-__all__ = ["Client"]
+__all__ = ["Client", "RESTClient"]

--- a/src/citric/_rest/__init__.py
+++ b/src/citric/_rest/__init__.py
@@ -1,7 +1,0 @@
-"""LimeSurvey REST API client."""
-
-from __future__ import annotations
-
-from .client import RESTClient
-
-__all__ = ["RESTClient"]

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -42,7 +42,7 @@ EMAILS_SENT_STATUS_PATTERN = re.compile(r"(-?\d+) left to send")
 
 
 class Client:  # noqa: PLR0904
-    """LimeSurvey Remote Control client.
+    """LimeSurvey RemoteControl 2 API client.
 
     Offers explicit wrappers for RPC methods and simplifies common workflows.
 

--- a/src/citric/rest.py
+++ b/src/citric/rest.py
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
+__all__ = [
+    "RESTClient",
+]
+
 
 class RESTClient:
     """LimeSurvey REST API client.

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -11,8 +11,8 @@ import pytest
 import requests.exceptions
 import semver
 
-from citric._rest import RESTClient  # noqa: PLC2701
 from citric.exceptions import LimeSurveyStatusError
+from citric.rest import RESTClient
 
 if sys.version_info >= (3, 12):
     from typing import override

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -12,7 +12,7 @@ import tinydb.storages
 from tinydb.table import Document
 from werkzeug.wrappers import Response
 
-from citric._rest import RESTClient  # noqa: PLC2701
+from citric.rest import RESTClient
 
 if TYPE_CHECKING:
     import sys


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

The REST API is sufficiently stable.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
