### PR TITLE
packaging: The `tests` directory is now included in the source distribution

### DIFF
--- a/.changes/unreleased/Packaging-20251017-210050.yaml
+++ b/.changes/unreleased/Packaging-20251017-210050.yaml
@@ -1,0 +1,5 @@
+kind: Packaging
+body: The `tests` directory is now included in the source distribution
+time: 2025-10-17T21:00:50.274294-06:00
+custom:
+    Issue: "1553"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,12 @@ samples = [
   "pandas>=2.0.3",
 ]
 
+[tool.hatch.build.targets.sdist]
+packages = [ "src/citric", "tests" ]
+
+[tool.hatch.build.targets.wheel]
+packages = [ "src/citric" ]
+
 [tool.ruff]
 line-length = 88
 src = [
@@ -106,7 +112,6 @@ src = [
   "src",
   "tests",
 ]
-
 include = [
   "**/pyproject.toml",
   "*.ipynb",


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Test Plan

<!-- How was it tested? -->

NA.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. -->

- [x] My pull request has a descriptive title.
- [x] I have read the [CONTRIBUTING] guide.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] If appropriate, I have added necessary documentation.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

For both the title of the PR and the changelog entry, prefer simple past tense or constructions with "now". For example:

- Added `Client.invite_participants()`
- `Client.user_activation_settings()` now accepts a `user_activation_settings` keyword argument

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
