### PR TITLE
chore: Use `codespell` with `typos`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,4 +75,4 @@ jobs:
           file: ${{ steps.attest.outputs.bundle-path }}
           tag: ${{ github.event.inputs.tag || github.ref }}
           overwrite: false
-          asset_name: attestations.intoto.jsonl  # codespell:ignore intoto
+          asset_name: attestations.intoto.jsonl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,15 +38,11 @@ repos:
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
   - id: ruff-format
 
-- repo: https://github.com/codespell-project/codespell
-  rev: v2.4.1
+- repo: https://github.com/crate-ci/typos
+  rev: v1.40.0
   hooks:
-  - id: codespell
-    exclude: |
-      (?x)^(
-        uv\.lock|
-        requirements/requirements.*\.txt
-      )$
+  - id: typos
+    args: []
 
 - repo: https://github.com/pre-commit/pre-commit
   rev: v4.5.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ html_theme_options = {
     "source_directory": "docs/",
 }
 html_title = "Citric, a Python client for LimeSurvey"
+html_short_title = "Citric"
 html_extra_path = [
     "googled10b55fb460af091.html",
     "code.png",

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,3 +1,9 @@
+```{eval-rst}
+.. meta::
+    :description:
+        How-to guides for the Citric LimeSurvey client.
+```
+
 # How-to Guide
 
 For the full JSON-RPC reference, see the [RemoteControl 2 API docs][rc2api].

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,7 @@
 ```{eval-rst}
 .. meta::
-    :description lang=en:
+    :description:
         A Python client for the LimeSurvey Remote Control API 2.
-    :description lang=es:
-        Un cliente de Python para la API de control remoto de LimeSurvey.
 ```
 
 # Citric

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,10 +222,6 @@ lint.pydocstyle.convention = "google"
 lint.pylint.max-args = 10
 lint.preview = true
 
-[tool.codespell]
-ignore-words-list = "socio-economic"
-skip = ".mypy_cache,.nox,.ruff_cache,build,docs/index.md"
-
 [tool.deptry]
 pep621_dev_dependency_groups = [
   "dev",
@@ -329,3 +325,7 @@ include = [
 
 [tool.ty.terminal]
 error-on-warning = true
+
+[tool.typos.default.extend-words]
+erronous = "erronous" # This is a typo in a LimeSurvey API field name
+intoto = "intoto"     # https://in-toto.io/

--- a/src/citric/rest.py
+++ b/src/citric/rest.py
@@ -204,7 +204,7 @@ class RESTClient:
                 - props: Properties to update
 
         Returns:
-            Patch operation result with operationsApplied and erronousOperations.
+            Patch operation result with operationsApplied.
 
         Examples:
             >>> # Update multiple question answers at once
@@ -225,7 +225,7 @@ class RESTClient:
             ...         },
             ...     ],
             ... )
-            {'operationsApplied': 2, 'erronousOperations': []}
+            {'operationsApplied': 2}
 
         .. versionadded:: NEXT_VERSION
         """


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Detects CamelCase, kebab-case and snake_case typos.

https://github.com/crate-ci/typos/issues/316 is a bummer, but not a deal-breaker.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
