### PR TITLE
ci: Display ty output directly in PRs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -128,7 +128,7 @@ def ty(session: nox.Session) -> None:
     session.run(
         "ty",
         "check",
-        f"--output-format={'github' if os.getenv('GITHUB_ACTIONS') == 'true' else 'concise'}",
+        f"--output-format={'github' if os.getenv('GITHUB_ACTIONS') == 'true' else 'concise'}",  # noqa: E501
         *args,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -125,7 +125,12 @@ def ty(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
     session.install(".", "--group=typing")
-    session.run("ty", "check", *args)
+    session.run(
+        "ty",
+        "check",
+        f"--output-format={'github' if os.getenv('GITHUB_ACTIONS') == 'true' else 'concise'}",
+        *args,
+    )
 
 
 @nox.session(name="docs-build", python=DOCS_PYTHON)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ samples = [
 ]
 
 [tool.uv]
-exclude-newer = "7 days"
+exclude-newer = "P7D"
 preview = true
 required-version = ">=0.9.17"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,15 +317,15 @@ module = [
   "nox.*",
 ]
 
+[tool.ty.rules]
+unused-type-ignore-comment = "ignore"
+
 [tool.ty.src]
 include = [
   "src",
   "tests",
   "docs/conf.py",
 ]
-
-[tool.ty.terminal]
-error-on-warning = false
 
 [tool.typos.default.extend-words]
 erronous = "erronous" # This is a typo in a LimeSurvey API field name


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
