### PR TITLE
docs: Put contributing documents in a dropdown to declutter the sidenav

### DIFF
--- a/.changes/unreleased/Documentation-20260216-124428.yaml
+++ b/.changes/unreleased/Documentation-20260216-124428.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Put contributing documents in a dropdown to declutter the sidenav
+time: 2026-02-16T12:44:28.195941-06:00
+custom:
+    Issue: "1667"

--- a/docs/contributing/docs.md
+++ b/docs/contributing/docs.md
@@ -4,7 +4,7 @@ If you've already [set up your environment][environment], you can build the
 documentation site and watch the repo for changes:
 
 ```shell
-nox -rs docs-serve
+nox -s docs-serve
 ```
 
 [environment]: /contributing/environment

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,0 +1,13 @@
+# Contributing
+
+```{toctree}
+getting-started
+environment
+testing
+docs
+docker
+release
+new-limesurvey-features
+update-dependencies
+code-of-conduct
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,16 +75,8 @@ license
 ```
 
 ```{toctree}
-:caption: Contributing
+:maxdepth: 1
 :hidden:
 
-contributing/code-of-conduct
-contributing/getting-started
-contributing/environment
-contributing/testing
-contributing/docs
-contributing/docker
-contributing/release
-contributing/new-limesurvey-features
-contributing/update-dependencies
+./contributing/index.md
 ```


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
