### PR TITLE
chore: Remove unused docs dependency `autodocsumm`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ test = [
   "xdoctest[colors]>=1.1.1",
 ]
 docs = [
-  "autodocsumm>=0.2.5",       # 0.2.4 has a problematic dependency 'Sphinx>=2.2.*'
   "docutils>=0.20",
   "furo>=2024.1.29",
   "myst-parser>=2",

--- a/requirements/docs.requirements.txt
+++ b/requirements/docs.requirements.txt
@@ -6,8 +6,6 @@ alabaster==1.0.0
     # via sphinx
 astroid==4.0.3
     # via sphinx-autoapi
-autodocsumm==0.2.14
-    # via citric (pyproject.toml:docs)
 babel==2.18.0
     # via sphinx
 beautifulsoup4==4.14.3
@@ -71,7 +69,6 @@ soupsieve==2.8.3
 sphinx==8.2.3
     # via
     #   citric (pyproject.toml:docs)
-    #   autodocsumm
     #   furo
     #   myst-parser
     #   sphinx-autoapi


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

We aren't even using it, and it's preventing a bump to Sphinx 9 (https://github.com/Chilipp/autodocsumm/issues/108).

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html
