### PR TITLE
ci: Valide sdist contents with `check-sdist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Agents
+.claude/
+
 # Temp files
 *.temp.*
 
@@ -148,13 +151,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,12 @@ repos:
     hooks:
       - id: mdformat
         exclude: \.github/pull_request_template\.md
+
+  - repo: https://github.com/henryiii/check-sdist
+    rev: v1.3.2
+    hooks:
+      - id: check-sdist
+        language: python
+        args: [--inject-junk]
+        additional_dependencies:
+          - hatchling==1.28.0


### PR DESCRIPTION
https://github.com/henryiii/check-sdist

## Summary by Sourcery

CI:
- Integrate the check-sdist pre-commit hook (with hatchling dependency) to verify sdist contents during development.