### PR TITLE
test: Added tests for the REST API to validate updating a question, question l10n attributes and subquestions

### DIFF
--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -239,6 +239,20 @@ def test_update_question_answers(
     assert sorted_answers[2]["l10ns"]["en"]["answer"] == "TOO LITTLE!"
 
 
+def _xfail(
+    condition: bool,  # noqa: FBT001
+    request: pytest.FixtureRequest,
+    *,
+    reason: str,
+    server_version: semver.Version,
+    **kwargs: Any,
+) -> None:
+    if condition:
+        kwargs.setdefault("strict", True)
+        message = f"{reason}\nCurrent server version is {server_version}."
+        request.applymarker(pytest.mark.xfail(reason=message, **kwargs))
+
+
 @pytest.mark.integration_test
 def test_patch_question(
     server_version: semver.Version,
@@ -247,17 +261,22 @@ def test_patch_question(
     survey_with_question_answers: int,
 ) -> None:
     """Test patching a question's properties."""
-    if server_version <= (6, 2):
-        request.applymarker(
-            pytest.mark.xfail(
-                reason=(
-                    "At some point after 6.2, `questionGroups` changed from a dict "
-                    "to a list. We don't bother to test for older versions."
-                ),
-                raises=KeyError,
-                strict=True,
-            )
-        )
+    _xfail(
+        server_version <= (6, 2),
+        request,
+        reason=(
+            "At some point after 6.2, `questionGroups` changed from a dict to a list. "
+            "We don't bother to test for older versions."
+        ),
+        server_version=server_version,
+        raises=KeyError,
+    )
+    _xfail(
+        (6, 15, 18) <= server_version <= (6, 15, 20),
+        request,
+        reason="PATCH for question answers is broken in 6.15.18, 6.15.19 and 6.15.20.",
+        server_version=server_version,
+    )
 
     survey = rest_client.get_survey_details(survey_id=survey_with_question_answers)
     question = survey["questionGroups"][0]["questions"][0]
@@ -293,17 +312,16 @@ def test_patch_question_l10n(
     survey_with_question_answers: int,
 ) -> None:
     """Test patching question localizations."""
-    if server_version <= (6, 2):
-        request.applymarker(
-            pytest.mark.xfail(
-                reason=(
-                    "At some point after 6.2, `questionGroups` changed from a dict "
-                    "to a list. We don't bother to test for older versions."
-                ),
-                raises=KeyError,
-                strict=True,
-            )
-        )
+    _xfail(
+        server_version <= (6, 2),
+        request,
+        reason=(
+            "At some point after 6.2, `questionGroups` changed from a dict to a list. "
+            "We don't bother to test for older versions."
+        ),
+        server_version=server_version,
+        raises=KeyError,
+    )
 
     survey = rest_client.get_survey_details(survey_id=survey_with_question_answers)
     question = survey["questionGroups"][0]["questions"][0]
@@ -340,17 +358,22 @@ def test_patch_subquestions(
     survey_with_question_answers: int,
 ) -> None:
     """Test patching subquestions."""
-    if server_version <= (6, 2):
-        request.applymarker(
-            pytest.mark.xfail(
-                reason=(
-                    "At some point after 6.2, `questionGroups` changed from a dict "
-                    "to a list. We don't bother to test for older versions."
-                ),
-                raises=KeyError,
-                strict=True,
-            )
-        )
+    _xfail(
+        server_version <= (6, 2),
+        request,
+        reason=(
+            "At some point after 6.2, `questionGroups` changed from a dict to a list. "
+            "We don't bother to test for older versions."
+        ),
+        server_version=server_version,
+        raises=KeyError,
+    )
+    _xfail(
+        (6, 15, 18) <= server_version <= (6, 15, 20),
+        request,
+        reason="PATCH for question answers is broken in 6.15.18, 6.15.19 and 6.15.20.",
+        server_version=server_version,
+    )
 
     def _subquestions(survey: dict[str, Any]) -> tuple[int | None, list]:
         for question in survey["questionGroups"][0]["questions"]:

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -237,3 +237,158 @@ def test_update_question_answers(
     assert sorted_answers[0]["l10ns"]["en"]["answer"] == "TOO MUCH!"
     assert sorted_answers[1]["l10ns"]["en"]["answer"] == "JAR"
     assert sorted_answers[2]["l10ns"]["en"]["answer"] == "TOO LITTLE!"
+
+
+@pytest.mark.integration_test
+def test_patch_question(
+    server_version: semver.Version,
+    request: pytest.FixtureRequest,
+    rest_client: RESTClient,
+    survey_with_question_answers: int,
+) -> None:
+    """Test patching a question's properties."""
+    if server_version <= (6, 2):
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    "At some point after 6.2, `questionGroups` changed from a dict "
+                    "to a list. We don't bother to test for older versions."
+                ),
+                raises=KeyError,
+                strict=True,
+            )
+        )
+
+    survey = rest_client.get_survey_details(survey_id=survey_with_question_answers)
+    question = survey["questionGroups"][0]["questions"][0]
+    qid = question["qid"]
+
+    result = rest_client.patch_survey(
+        survey_id=survey_with_question_answers,
+        patch_operations=[
+            {
+                "entity": "question",
+                "op": "update",
+                "id": qid,
+                "props": {"mandatory": True},
+            },
+        ],
+    )
+    assert result["operationsApplied"] == 1
+
+    updated_survey = rest_client.get_survey_details(
+        survey_id=survey_with_question_answers
+    )
+    updated_question = next(
+        q for q in updated_survey["questionGroups"][0]["questions"] if q["qid"] == qid
+    )
+    assert updated_question["mandatory"] is True
+
+
+@pytest.mark.integration_test
+def test_patch_question_l10n(
+    server_version: semver.Version,
+    request: pytest.FixtureRequest,
+    rest_client: RESTClient,
+    survey_with_question_answers: int,
+) -> None:
+    """Test patching question localizations."""
+    if server_version <= (6, 2):
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    "At some point after 6.2, `questionGroups` changed from a dict "
+                    "to a list. We don't bother to test for older versions."
+                ),
+                raises=KeyError,
+                strict=True,
+            )
+        )
+
+    survey = rest_client.get_survey_details(survey_id=survey_with_question_answers)
+    question = survey["questionGroups"][0]["questions"][0]
+    qid = question["qid"]
+    new_text = "Updated question text"
+
+    result = rest_client.patch_survey(
+        survey_id=survey_with_question_answers,
+        patch_operations=[
+            {
+                "entity": "questionL10n",
+                "op": "update",
+                "id": qid,
+                "props": {"en": {"question": new_text}},
+            },
+        ],
+    )
+    assert result["operationsApplied"] == 1
+
+    updated_survey = rest_client.get_survey_details(
+        survey_id=survey_with_question_answers
+    )
+    updated_question = next(
+        q for q in updated_survey["questionGroups"][0]["questions"] if q["qid"] == qid
+    )
+    assert updated_question["l10ns"]["en"]["question"] == new_text
+
+
+@pytest.mark.integration_test
+def test_patch_subquestions(
+    server_version: semver.Version,
+    request: pytest.FixtureRequest,
+    rest_client: RESTClient,
+    survey_with_question_answers: int,
+) -> None:
+    """Test patching subquestions."""
+    if server_version <= (6, 2):
+        request.applymarker(
+            pytest.mark.xfail(
+                reason=(
+                    "At some point after 6.2, `questionGroups` changed from a dict "
+                    "to a list. We don't bother to test for older versions."
+                ),
+                raises=KeyError,
+                strict=True,
+            )
+        )
+
+    def _subquestions(survey: dict[str, Any]) -> tuple[int | None, list]:
+        for question in survey["questionGroups"][0]["questions"]:
+            if subquestions := question.get("subquestions"):
+                return question["qid"], subquestions
+        return None, []
+
+    survey = rest_client.get_survey_details(survey_id=survey_with_question_answers)
+    qid, subquestions = _subquestions(survey)
+    assert subquestions
+
+    new_text = "First option - updated"
+
+    # Build updated props preserving all subquestions, modifying the first one
+    updated_subquestions = [
+        {**sq, "l10ns": {lang: {**l10n} for lang, l10n in sq["l10ns"].items()}}
+        for sq in subquestions
+    ]
+    updated_subquestions[0]["l10ns"]["en"]["question"] = new_text
+
+    result = rest_client.patch_survey(
+        survey_id=survey_with_question_answers,
+        patch_operations=[
+            {
+                "entity": "subquestion",
+                "op": "update",
+                "id": qid,
+                "props": {str(i): sq for i, sq in enumerate(updated_subquestions)},
+            },
+        ],
+    )
+    assert result["operationsApplied"] == 1
+
+    updated_survey = rest_client.get_survey_details(
+        survey_id=survey_with_question_answers
+    )
+    _, result_subquestions = _subquestions(updated_survey)
+    updated_first_sq = next(
+        sq for sq in result_subquestions if sq["qid"] == subquestions[0]["qid"]
+    )
+    assert updated_first_sq["l10ns"]["en"]["question"] == new_text


### PR DESCRIPTION
SSIA

## Summary by Sourcery

Add integration coverage for patching questions, their localizations, and subquestions via the REST survey patch API.

Tests:
- Add an integration test verifying question properties can be updated via question patch operations.
- Add an integration test verifying localized question text can be updated via questionL10n patch operations.
- Add an integration test verifying subquestion localizations can be updated via subquestion patch operations, including handling for older server versions.