### PR TITLE
ci: Switch to `actions/attest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           name: Packages
           path: dist
-      - uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         id: attest
         with:
           subject-path: "./dist/citric*"


### PR DESCRIPTION
SSIA

## Summary by Sourcery

CI:
- Update the build workflow to replace actions/attest-build-provenance with actions/attest v4.1.0 for artifact attestation.