### PR TITLE
fix: Removed `one_time_pw` from `UserDetails` typed dict since it's only exposed by mistake in older LimeSurvey versions and it's a security bug

### DIFF
--- a/.changes/unreleased/Fixed-20260317-221514.yaml
+++ b/.changes/unreleased/Fixed-20260317-221514.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: 'fix: Removed `one_time_pw` from `UserDetails` typed dict since it''s only exposed by mistake in older LimeSurvey versions and it''s a security bug'
+time: 2026-03-17T22:15:14.15932-06:00
+custom:
+    Issue: "9999"

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -770,9 +770,6 @@ class UserDetails(TypedDict, total=False):
     questionselectormode: str
     """The user preferred question type selector."""
 
-    one_time_pw: str
-    """The user one-time password."""
-
     dateformat: int
     """The user date format."""
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

See upstream: https://github.com/LimeSurvey/LimeSurvey/commit/bc9bc9bda0de656538d9e0ff6b0114e03701f364.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Remove the mistakenly exposed one-time password field from user detail typings and document the security fix.

Bug Fixes:
- Remove the `one_time_pw` field from the `UserDetails` typed dict to prevent exposing a deprecated and security-sensitive value.

Documentation:
- Add a changelog entry describing the removal of the `one_time_pw` field from `UserDetails` as a security fix.

## Summary by Sourcery

Remove the mistakenly exposed one-time password field from the UserDetails type and document the fix in the changelog.

Bug Fixes:
- Stop treating the one-time password as part of the UserDetails typed dict to avoid exposing a security-sensitive field.

Documentation:
- Add an unreleased changelog entry describing the removal of the one-time password field from UserDetails.