### PR TITLE
ci: Replace superfluous actions with shell scripts

### DIFF
--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -34,7 +34,6 @@ jobs:
     permissions:
       contents: write       # to create a github release
       pull-requests: write  # to create and update PRs
-      discussions: write    # to create a discussion
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -71,40 +70,70 @@ jobs:
     - name: Draft Release
       id: draft-release
       if: ${{ github.event.inputs.prerelease == '' }}
-      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-      with:
-        draft: true
-        body_path: ".changes/${{ steps.latest.outputs.output }}.md"
-        tag_name: ${{ steps.latest.outputs.output }}
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LATEST: ${{ steps.latest.outputs.output }}
+      run: |
+        url=$(gh release create "$LATEST" \
+          --draft \
+          --notes-file ".changes/${LATEST}.md")
+        echo "url=${url}" >> "$GITHUB_OUTPUT"
 
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: generate-token
       with:
         app-id: ${{ vars.APP_ID }}
-        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+
+    - name: Get GitHub App User ID
+      id: get-user-id
+      run: echo "user-id=$(gh api "/users/${APP_USERNAME}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        APP_USERNAME: ${{ steps.generate-token.outputs.app-slug }}
+
+    - name: Configure bot user
+      env:
+        APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        APP_USERNAME: ${{ steps.generate-token.outputs.app-slug }}
+      run: |
+        git config --global user.name "${APP_USERNAME}[bot]"
+        git config --global user.email "${APP_USER_ID}+${APP_USERNAME}[bot]@users.noreply.github.com"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-      with:
-        token: ${{ steps.generate-token.outputs.token }}
-        title: "chore: Release ${{ steps.latest.outputs.output }}"
-        branch: release/${{ steps.latest.outputs.output }}
-        commit-message: "chore: Release ${{ steps.latest.outputs.output }}"
-        body: |
-          Prepare release for `${{ steps.latest.outputs.output }}`.
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        VERSION: ${{ steps.latest.outputs.output }}
+        DRAFT_URL: ${{ steps.draft-release.outputs.url }}
+      run: |
+        branch_name="release/${VERSION}"
 
-          Checklist:
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git checkout -b $branch_name
+        git add .
 
-          - [ ] Check that the right version is set in all the files.
-          - [ ] Groom the changelog for wording or missing entries.
-          - [ ] Check that the integration tests table is up to date.
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
 
-          [Release Draft](${{ steps.draft-release.outputs.url }})
-        reviewers: |
-          edgarrmondragon
-        assignees: |
-          edgarrmondragon
-        delete-branch: true
-        labels: Release
+        git commit -m "chore: Release ${VERSION}"
+        git fetch origin $branch_name || true
+        git push --force-with-lease origin $branch_name
+
+        cat > /tmp/pr-body.md << 'EOF'
+        Checklist:
+
+        - [ ] Check that the right version is set in all the files.
+        - [ ] Groom the changelog for wording or missing entries.
+        - [ ] Check that the integration tests table is up to date.
+        EOF
+        if [ -n "${DRAFT_URL}" ]; then
+          printf '\n\n[Release Draft](%s)\n' "${DRAFT_URL}" >> /tmp/pr-body.md
+        fi
+
+        gh pr create \
+          --title "chore: Release ${VERSION}" \
+          --body-file /tmp/pr-body.md \
+          --base main \
+          --label Release

--- a/.github/workflows/limesurvey-tags.yml
+++ b/.github/workflows/limesurvey-tags.yml
@@ -28,36 +28,70 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
+
     - name: Install tools
       uses: ./.github/actions/install-tools
       with:
         nox-version: ${{ env.NOX_VERSION }}
         uv-version: ${{ env.UV_VERSION }}
+
     - name: Update tags
       run: ./scripts/docker_tags.py
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
       id: generate-token
       with:
         app-id: ${{ vars.APP_ID }}
-        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+
+    - name: Get GitHub App User ID
+      id: get-user-id
+      run: echo "user-id=$(gh api "/users/${APP_USERNAME}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        APP_USERNAME: ${{ steps.generate-token.outputs.app-slug }}
+
+    - name: Configure bot user
+      env:
+        APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        APP_USERNAME: ${{ steps.generate-token.outputs.app-slug }}
+      run: |
+        git config --global user.name "${APP_USERNAME}[bot]"
+        git config --global user.email "${APP_USER_ID}+${APP_USERNAME}[bot]@users.noreply.github.com"
+
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
-      with:
-        token: ${{ steps.generate-token.outputs.token }}
-        title: "chore: Update LimeSurvey Docker tags"
-        branch: docker/update-tags
-        commit-message: "chore: Update LimeSurvey Docker tags"
-        body: |
-          This PR updates the tags for the LimeSurvey Docker images.
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      run: |
+        branch_name="docker/update-tags"
 
-          Links:
+        git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git checkout -b $branch_name
+        git add .
 
-          - [Docker Hub](https://hub.docker.com/r/martialblog/limesurvey/tags)
-          - [LimeSurvey tags](https://github.com/LimeSurvey/LimeSurvey/tags)
-        reviewers: |
-          edgarrmondragon
-        assignees: |
-          edgarrmondragon
-        delete-branch: true
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+          exit 0
+        fi
+
+        git commit -m "chore: Update LimeSurvey Docker tags"
+        git fetch origin $branch_name || true
+        git push --force-with-lease origin $branch_name
+
+        cat > /tmp/pr-body.md << 'EOF'
+        This PR updates the tags for the LimeSurvey Docker images.
+
+        Links:
+
+        - [Docker Hub](https://hub.docker.com/r/martialblog/limesurvey/tags)
+        - [LimeSurvey tags](https://github.com/LimeSurvey/LimeSurvey/tags)
+        EOF
+
+        # If a PR already exists the push already updated it, so creation is skipped.
+        if ! gh pr list --head "$branch_name" --json number --jq '.[0].number' | grep -q .; then
+          gh pr create \
+            --title "chore: Update LimeSurvey Docker tags" \
+            --body-file /tmp/pr-body.md
+        fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
       if: ${{ !cancelled() }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
         files: tests.xml
         flags: unit-${{ matrix.os }}-${{ matrix.python-version }}
         report_type: test_results
@@ -273,7 +273,7 @@ jobs:
       if: ${{ !cancelled() }}
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
         files: integration.xml
         flags: integration-${{ matrix.python-version }}-${{ matrix.image_tag || matrix.ref }}-${{ matrix.database }}
         report_type: test_results
@@ -339,7 +339,7 @@ jobs:
     - name: Upload coverage report
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }} # zizmor: ignore[secrets-outside-env]
         files: ./coverage.xml
         fail_ci_if_error: true
         flags: ${{ matrix.flag }}


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Makes zizmor happy.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Replace third-party GitHub Actions with direct gh CLI and git commands in release and tag update workflows, and adjust secret usage annotations for compatibility with zizmor.

CI:
- Create release drafts and pull requests in release workflow via gh CLI and git instead of softprops/action-gh-release and peter-evans/create-pull-request actions.
- Create LimeSurvey Docker tag update pull requests via gh CLI and git instead of the create-pull-request action, including bot user configuration using a GitHub App token.
- Remove unnecessary discussions permission from the release workflow and annotate Codecov and GitHub App secrets to satisfy zizmor checks.