### PR TITLE
ci: Switch to `griffecli`

### DIFF
--- a/.github/workflows/api-changes.yml
+++ b/.github/workflows/api-changes.yml
@@ -14,8 +14,8 @@ concurrency:
 
 env:
   FORCE_COLOR: 1
-  # renovate: datasource=pypi depName=griffe
-  GRIFFE_VERSION: 2.0.0
+  # renovate: datasource=pypi depName=griffecli
+  GRIFFECLI_VERSION: 2.0.0
   # renovate: datasource=pypi depName=nox
   NOX_VERSION: 2026.2.9
   # renovate: datasource=pypi depName=uv
@@ -50,11 +50,11 @@ jobs:
     - name: Install tools
       run: |
         uv tool install --with nox==${NOX_VERSION} nox
-        uv tool install --with griffe==${GRIFFE_VERSION} griffe
+        uv tool install --with griffecli==${GRIFFECLI_VERSION} griffecli
         uv tool list
       env:
         NOX_VERSION: ${{ env.NOX_VERSION }}
-        GRIFFE_VERSION: ${{ env.GRIFFE_VERSION }}
+        GRIFFECLI_VERSION: ${{ env.GRIFFECLI_VERSION }}
 
     - name: Set REF
       id: set-ref

--- a/noxfile.py
+++ b/noxfile.py
@@ -188,7 +188,7 @@ def docs_serve(session: nox.Session) -> None:
 def api_changes(session: nox.Session) -> None:
     """Check for API changes."""
     args = [
-        "griffe",
+        "griffecli",
         "check",
         "citric",
         "-s=src",


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Switch API-change checking in CI and nox to use the griffecli tool instead of griffe.

Enhancements:
- Change the nox api_changes session to invoke griffecli for API checks.

CI:
- Update API changes GitHub workflow to install and use griffecli with a pinned version.