### PR TITLE
fix: Updated the type annotation and docstring of `delete_participants` to reflect the actual type of the returned value

### DIFF
--- a/.changes/unreleased/Fixed-20260406-103648.yaml
+++ b/.changes/unreleased/Fixed-20260406-103648.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Updated the type annotation and docstring of `delete_participants` to reflect the actual type of the returned value
+time: 2026-04-06T10:36:48.335881-06:00
+custom:
+    Issue: "1727"

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -305,7 +305,7 @@ class Client:  # noqa: PLR0904
         survey_id: int,
         participant_ids: Sequence[int],
     ) -> dict[str, Any]:
-        """Add participants to a survey.
+        """Delete participants from a survey.
 
         Calls :rpc_method:`delete_participants`.
 

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -304,7 +304,7 @@ class Client:  # noqa: PLR0904
         self,
         survey_id: int,
         participant_ids: Sequence[int],
-    ) -> list[dict[str, Any]]:
+    ) -> dict[str, Any]:
         """Add participants to a survey.
 
         Calls :rpc_method:`delete_participants`.
@@ -314,7 +314,7 @@ class Client:  # noqa: PLR0904
             participant_ids: Participant IDs to be deleted.
 
         Returns:
-            Information of removed participants.
+            Mapping of participant token IDs to deletion status.
 
         .. versionadded:: 0.0.1
         """

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -818,8 +818,8 @@ def test_participants(
             assert ple["participant_info"]["email"] == d["email"]
             assert ple["participant_info"]["firstname"] == d["firstname"]
             assert ple["participant_info"]["lastname"] == d["lastname"]
-            assert ple["attribute_1"] == d["attribute_1"]  # type: ignore[typeddict-item]
-            assert ple["attribute_2"] == d["attribute_2"]  # type: ignore[typeddict-item]
+            assert ple["attribute_1"] == d["attribute_1"]  # type: ignore[typeddict-item]  # ty:ignore[invalid-key]
+            assert ple["attribute_2"] == d["attribute_2"]  # type: ignore[typeddict-item]  # ty:ignore[invalid-key]
 
     # Get participant properties
     for p, d in zip(added, participants[:2], strict=False):


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Align delete_participants API documentation and typing with its actual return structure.

Bug Fixes:
- Correct delete_participants return type annotation and docstring to describe the mapping returned by the API.

Enhancements:
- Adjust integration test type ignores for participant attribute keys to reflect current typing expectations.

Documentation:
- Clarify delete_participants docstring to describe the returned mapping from participant token IDs to deletion status.

Tests:
- Update integration tests’ type-ignores for participant attributes to match updated type-checker behavior.

Chores:
- Add a changelog entry documenting the correction to delete_participants’ return type.