### PR TITLE
fix: Fixed typos in `SurveyProperties` fields

### DIFF
--- a/.changes/unreleased/Fixed-20260408-144248.yaml
+++ b/.changes/unreleased/Fixed-20260408-144248.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Fixed typos in `SurveyProperties` fields
+time: 2026-04-08T14:42:48.213064-06:00
+custom:
+    Issue: "1711"

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -474,13 +474,13 @@ class SurveyProperties(TypedDict, total=False):
     format: enums.NewSurveyType
     """The survey format."""
 
-    savetiming: YesNo
+    savetimings: YesNo
     """Whether the survey saves timing."""
 
     template: str
     """The survey template."""
 
-    datesstamp: YesNo
+    datestamp: YesNo
     """Whether the survey stamps dates."""
 
     usecookie: YesNo

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -163,10 +163,36 @@ def test_survey(
     copied = client.copy_survey(survey_id, NEW_SURVEY_NAME)
     assert copied["status"] == "OK"
 
-    # Get survey properties
+    # Get default properties
     survey_props = client.get_survey_properties(survey_id)
     assert survey_props["language"] == "es"
     assert survey_props["format"] == enums.NewSurveyType.GROUP_BY_GROUP
+
+    # Update survey properties
+    response = client.set_survey_properties(
+        survey_id,
+        format=enums.NewSurveyType.ALL_ON_ONE_PAGE,
+        savetimings="N",
+        datestamp="Y",
+    )
+    assert response == {
+        "format": True,
+        "savetimings": True,
+        "datestamp": True,
+    }
+
+    # Get updated survey properties
+    survey_props = client.get_survey_properties(
+        survey_id,
+        properties=[
+            "format",
+            "savetimings",
+            "datestamp",
+        ],
+    )
+    assert survey_props["format"] == enums.NewSurveyType.ALL_ON_ONE_PAGE
+    assert survey_props["savetimings"] == "N"
+    assert survey_props["datestamp"] == "Y"
 
     matched = next(s for s in client.list_surveys() if int(s["sid"]) == survey_id)
     assert matched["surveyls_title"] == NEW_SURVEY_NAME
@@ -181,16 +207,6 @@ def test_survey(
         gsid = matched["gsid"]
         surveys_in_group = client.list_surveys(survey_group_id=gsid)
         assert all(s["gsid"] == gsid for s in surveys_in_group)
-
-    # Update survey properties
-    response = client.set_survey_properties(
-        survey_id,
-        format=enums.NewSurveyType.ALL_ON_ONE_PAGE,
-    )
-    assert response == {"format": True}
-
-    new_props = client.get_survey_properties(survey_id, properties=["format"])
-    assert new_props["format"] == enums.NewSurveyType.ALL_ON_ONE_PAGE
 
 
 @pytest.mark.integration_test


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

`savetiming` → `savetimings`
`datesstamp` → `datestamp`

## Related

- Closes https://github.com/edgarrmondragon/citric/issues/1711

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Fix SurveyProperties field names and align tests and changelog with the corrected properties.

Bug Fixes:
- Correct SurveyProperties field names to use 'savetimings' and 'datestamp' in the public types.

Documentation:
- Add a changelog entry documenting the SurveyProperties field name corrections.

Tests:
- Extend the survey integration test to verify setting and retrieving the 'savetimings' and 'datestamp' properties via the RPC client.