### PR TITLE
ci: Also check types with Pyright

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -113,7 +113,7 @@ def dependencies(session: nox.Session) -> None:
     session.run("deptry", "src", "tests", "docs")
 
 
-@nox.session(tags=["lint"])
+@nox.session(tags=["lint", "types"])
 def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or [*locations, "noxfile.py"]
@@ -121,7 +121,7 @@ def mypy(session: nox.Session) -> None:
     session.run("mypy", *args)
 
 
-@nox.session(tags=["lint"])
+@nox.session(tags=["lint", "types"])
 def ty(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or locations
@@ -132,6 +132,14 @@ def ty(session: nox.Session) -> None:
         f"--output-format={'github' if os.getenv('GITHUB_ACTIONS') == 'true' else 'concise'}",  # noqa: E501
         *args,
     )
+
+
+@nox.session(tags=["lint", "types"])
+def pyright(session: nox.Session) -> None:
+    """Type-check using mypy."""
+    args = session.posargs or locations
+    session.install(".", "--group=typing")
+    session.run("pyright", *args)
 
 
 @nox.session(name="docs-build", python=DOCS_PYTHON)

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,7 @@ def mypy(session: nox.Session) -> None:
 
 @nox.session(tags=["lint", "types"])
 def ty(session: nox.Session) -> None:
-    """Type-check using mypy."""
+    """Type-check using ty."""
     args = session.posargs or locations
     session.install(".", "--group=typing")
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -136,7 +136,7 @@ def ty(session: nox.Session) -> None:
 
 @nox.session(tags=["lint", "types"])
 def pyright(session: nox.Session) -> None:
-    """Type-check using mypy."""
+    """Type-check using pyright."""
     args = session.posargs or locations
     session.install(".", "--group=typing")
     session.run("pyright", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ samples = [
 typing = [
   "backports-strenum",
   "mypy>=1.9",
+  "pyright>=1.1.408",
   "sphinx",
   "ty>=0.0.1a15",
   "types-requests>=2.31.0.2",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+# pyright: reportTypedDictNotRequiredAccess=none
+
 """Integration tests configuration."""
 
 from __future__ import annotations

--- a/tests/integration/test_rest_client.py
+++ b/tests/integration/test_rest_client.py
@@ -1,3 +1,5 @@
+# pyright: reportTypedDictNotRequiredAccess=none
+
 """Integration tests for the REST client."""
 
 from __future__ import annotations

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -1,3 +1,5 @@
+# pyright: reportTypedDictNotRequiredAccess=none
+
 """Integration tests for Python client."""
 
 from __future__ import annotations

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 import tinydb
-import tinydb.database
 import tinydb.storages
+import tinydb.table
 from tinydb.table import Document
 from werkzeug.wrappers import Response
 
@@ -37,7 +37,7 @@ def password() -> str:
 
 
 @pytest.fixture(scope="module")
-def backend() -> tinydb.database.Table:
+def backend() -> tinydb.table.Table:
     """TinyDB backend."""
     db = tinydb.TinyDB(storage=tinydb.storages.MemoryStorage)
     surveys = db.table("surveys")


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Add Pyright-based type checking to the project and align existing type-checking sessions and annotations accordingly.

New Features:
- Introduce a Nox session to run Pyright for type checking.

Enhancements:
- Tag existing mypy Nox sessions with a shared 'types' tag to group type-checking tasks.
- Adjust TinyDB test fixture type annotation to use the correct Table type from tinydb.table.

Build:
- Add Pyright to the optional 'typing' dependency group in pyproject.toml.