### PR TITLE
ci: Also check types with Pyrefly

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -142,6 +142,14 @@ def pyright(session: nox.Session) -> None:
     session.run("pyright", *args)
 
 
+@nox.session(tags=["lint", "types"])
+def pyrefly(session: nox.Session) -> None:
+    """Type-check using pyrefly."""
+    args = session.posargs or locations
+    session.install(".", "--group=typing")
+    session.run("pyrefly", "check", *args)
+
+
 @nox.session(name="docs-build", python=DOCS_PYTHON)
 def docs_build(session: nox.Session) -> None:
     """Build the documentation."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ samples = [
 typing = [
   "backports-strenum",
   "mypy>=1.9",
+  "pyrefly>=0.60",
   "pyright>=1.1.408",
   "sphinx",
   "ty>=0.0.1a15",
@@ -272,6 +273,13 @@ warn_unused_ignores = true
 overrides = [ { ignore_missing_imports = true, module = [
   "nox.*",
 ] } ]
+
+[tool.pyrefly]
+search-path = [ "." ]
+[[tool.pyrefly.sub-config]]
+matches = "tests/**"
+[tool.pyrefly.sub-config.errors]
+no-access = false
 
 [tool.ty]
 [tool.ty.rules]

--- a/src/citric/__init__.py
+++ b/src/citric/__init__.py
@@ -8,7 +8,7 @@ from citric import objects
 from citric.client import Client
 from citric.rest import RESTClient
 
-__version__ = metadata.version("citric")
+__version__: str = metadata.version("citric")
 """Package version"""
 
 del annotations, metadata  # noqa: RUF067

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -39,7 +39,7 @@ __all__ = [
     "Client",
 ]
 
-EMAILS_SENT_STATUS_PATTERN = re.compile(r"(-?\d+) left to send")
+EMAILS_SENT_STATUS_PATTERN: re.Pattern[str] = re.compile(r"(-?\d+) left to send")
 
 
 class Client:  # noqa: PLR0904

--- a/src/citric/rest.py
+++ b/src/citric/rest.py
@@ -50,7 +50,7 @@ class RESTClient:
         *,
         requests_session: requests.Session | None = None,
     ) -> None:
-        self.url = url
+        self.url: str = url
         self._session = requests_session or requests.session()
         self._session.headers["User-Agent"] = self.USER_AGENT
         self.__session_id: str | None = None

--- a/src/citric/session.py
+++ b/src/citric/session.py
@@ -34,7 +34,7 @@ __all__ = ["Session"]
 
 GET_SESSION_KEY = "get_session_key"
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 def handle_rpc_errors(result: Result, error: str | None) -> None:
@@ -105,7 +105,7 @@ class Session:
         requests_session: requests.Session | None = None,
         json_encoder: Type[json.JSONEncoder] | None = None,  # noqa: UP006
     ) -> None:
-        self.url = url
+        self.url: str = url
         self._session = requests_session or requests.session()
         self._session.headers["User-Agent"] = self.USER_AGENT
         self._encoder = json_encoder or json.JSONEncoder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,20 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import os
 from importlib.metadata import version
-from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
 import requests
 from dotenv import load_dotenv
-from requests.adapters import BaseAdapter
 
 from citric.session import Session
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
+from tests.fixtures import LimeSurveyMockAdapter
 
 load_dotenv()
 
@@ -179,86 +174,6 @@ def docker_context(request: pytest.FixtureRequest) -> str:
 def dockerfile(request: pytest.FixtureRequest) -> str:
     """Dockerfile."""
     return request.config.getoption("--limesurvey-dockerfile")
-
-
-class LimeSurveyMockAdapter(BaseAdapter):
-    """Requests adapter that mocks LSRC2 API calls."""
-
-    api_error_methods = ("__api_error",)
-    status_error_methods = ("__status_error",)
-    http_error_methods = ("__http_error",)
-    ok_methods = ("__ok", "release_session_key")
-    status_ok_methods = ("__status_ok", "activate_tokens", "delete_survey")
-
-    session_key = "123456"
-    status_ok: ClassVar[dict[str, Any]] = {"status": "OK"}
-    rpc_interface = "json"
-
-    ldap_session_key = "ldap-key"
-
-    def _handle_json_response(
-        self,
-        method: str,
-        params: list[Any],
-        request_id: int,
-    ) -> requests.Response:
-        response = requests.Response()
-        response.status_code = 200
-        output: dict[str, Any] = {"result": None, "error": None, "id": request_id}
-
-        if method in self.api_error_methods:
-            output["error"] = "API Error!"
-        elif method in self.status_error_methods:
-            output["result"] = {"status": "Status Error!"}
-        elif method in self.http_error_methods:
-            response.status_code = 500
-        elif method in self.ok_methods:
-            output["result"] = "OK"
-        elif method in self.status_ok_methods:
-            output["result"] = self.status_ok
-        elif method == "__bad_id":
-            output["id"] = 2
-        elif method == "get_session_key":
-            output["result"] = (
-                self.ldap_session_key if params[2] == "AuthLDAP" else self.session_key
-            )
-        elif method == "get_site_settings" and params[1] == "RPCInterface":
-            output["result"] = self.rpc_interface
-
-        response._content = json.dumps(output).encode()
-
-        return response
-
-    def send(
-        self,
-        request: requests.PreparedRequest,
-        stream: bool = False,  # noqa: FBT001, FBT002
-        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
-        verify: bool | str = True,  # noqa: FBT001, FBT002
-        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
-        proxies: Mapping[str, str] | None = None,
-    ):
-        """Send a mocked request."""
-        request_data = json.loads(request.body or "{}")
-        method = request_data["method"]
-        params = request_data["params"]
-        request_id = request_data.get("id", 1)
-
-        if method == "__disabled":
-            response = requests.Response()
-            response.status_code = 200
-            return response
-
-        if method == "__not_json":
-            response = requests.Response()
-            response.status_code = 200
-            response._content = b"this is not json"
-            return response
-
-        return self._handle_json_response(method, params, request_id)
-
-    def close(self) -> None:
-        """Clean up adapter specific items."""
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,8 +1,15 @@
-"""Mailpit API client."""
+"""Test fixtures and mock helpers."""
 
 from __future__ import annotations
 
+import json
+from typing import TYPE_CHECKING, Any, ClassVar
+
 import requests
+from requests.adapters import BaseAdapter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class MailpitClient:
@@ -22,3 +29,83 @@ class MailpitClient:
             timeout=10,
             params={"query": "after:2024/04/01"},
         )
+
+
+class LimeSurveyMockAdapter(BaseAdapter):
+    """Requests adapter that mocks LSRC2 API calls."""
+
+    api_error_methods = ("__api_error",)
+    status_error_methods = ("__status_error",)
+    http_error_methods = ("__http_error",)
+    ok_methods = ("__ok", "release_session_key")
+    status_ok_methods = ("__status_ok", "activate_tokens", "delete_survey")
+
+    session_key = "123456"
+    status_ok: ClassVar[dict[str, Any]] = {"status": "OK"}
+    rpc_interface = "json"
+
+    ldap_session_key = "ldap-key"
+
+    def _handle_json_response(
+        self,
+        method: str,
+        params: list[Any],
+        request_id: int,
+    ) -> requests.Response:
+        response = requests.Response()
+        response.status_code = 200
+        output: dict[str, Any] = {"result": None, "error": None, "id": request_id}
+
+        if method in self.api_error_methods:
+            output["error"] = "API Error!"
+        elif method in self.status_error_methods:
+            output["result"] = {"status": "Status Error!"}
+        elif method in self.http_error_methods:
+            response.status_code = 500
+        elif method in self.ok_methods:
+            output["result"] = "OK"
+        elif method in self.status_ok_methods:
+            output["result"] = self.status_ok
+        elif method == "__bad_id":
+            output["id"] = 2
+        elif method == "get_session_key":
+            output["result"] = (
+                self.ldap_session_key if params[2] == "AuthLDAP" else self.session_key
+            )
+        elif method == "get_site_settings" and params[1] == "RPCInterface":
+            output["result"] = self.rpc_interface
+
+        response._content = json.dumps(output).encode()
+
+        return response
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,  # noqa: FBT001, FBT002
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
+        verify: bool | str = True,  # noqa: FBT001, FBT002
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ):
+        """Send a mocked request."""
+        request_data = json.loads(request.body or "{}")
+        method = request_data["method"]
+        params = request_data["params"]
+        request_id = request_data.get("id", 1)
+
+        if method == "__disabled":
+            response = requests.Response()
+            response.status_code = 200
+            return response
+
+        if method == "__not_json":
+            response = requests.Response()
+            response.status_code = 200
+            response._content = b"this is not json"
+            return response
+
+        return self._handle_json_response(method, params, request_id)
+
+    def close(self) -> None:
+        """Clean up adapter specific items."""

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -20,8 +20,7 @@ from citric.exceptions import (
 )
 from citric.method import Method
 from citric.session import Session
-
-from .conftest import LimeSurveyMockAdapter
+from tests.fixtures import LimeSurveyMockAdapter
 
 if sys.version_info >= (3, 11):
     SET_PROPERTY_MESSAGE_REGEX = "property .* of 'Session' object has no setter"


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Add Pyrefly-based static type checking and adjust code and tests to satisfy stricter typing.

Enhancements:
- Move LimeSurvey test mock adapter into a shared fixtures module and generalize test fixtures utilities.
- Tighten type annotations in core modules, including URLs, logger, version, and compiled regex patterns.

Build:
- Add Pyrefly as a typing dependency and configure it in pyproject.toml.

CI:
- Introduce a nox session to run Pyrefly type checks alongside existing type-checking sessions.