### PR TITLE
feat: New `Survey` and `QuestionGroup` classes for composing surveys as Python objects for creating and importing them

### DIFF
--- a/.changes/Added-20260617-000000.yaml
+++ b/.changes/Added-20260617-000000.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: New `Survey`, `SurveyL10n`, and `QuestionGroup` classes for composing surveys as Python objects, exportable as LSS XML via `to_lss()` and updatable via `Client.update_survey()`
+time: 2026-06-17T00:00:00.000000-06:00
+custom:
+    Issue: "1679"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ source_suffix = {
 
 nitpicky = True
 nitpick_ignore = {
+    ("py:class", "citric.objects._question.Question"),
     ("py:class", "citric.types.Result"),
     ("py:class", "Result"),
     ("py:class", "YesNo"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ per-file-ignores."tests/*" = [
   "ANN201",  # missing-return-type-undocumented-public-function
   "ARG00",   # unused-method-argument
   "C901",    # complex-structure
+  "D103",    # undocumented-public-function
   "DOC201",  # docstring-missing-returns
   "DOC402",  # docstring-missing-yields
   "PLR2004", # magic-value-comparison
@@ -214,6 +215,8 @@ per-file-ignores."tests/*" = [
   "S101",    # assert
   "S105",    # hardcoded-password-string
   "S106",    # hardcoded-password-func-arg
+  "S314",    # suspicious-xml-element-tree-usage
+  "S405",    # suspicious-xml-element-tree-usage
   "SLF001",  # private-member-access
 ]
 unfixable = [

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     from citric import types
-    from citric.objects import Participant
+    from citric.objects import Participant, Survey
 
     if sys.version_info >= (3, 11):
         from typing import Self, Unpack
@@ -1780,9 +1780,39 @@ class Client:  # noqa: PLR0904
         Returns:
             Mapping of property names to whether they were set successfully.
 
+        .. note::
+
+           Prefer :meth:`update_survey`, which accepts a
+           :class:`~citric.types.SurveyProperties` mapping directly and is
+           more amenable to static type checking.
+
         .. versionadded:: 0.0.11
         """
         return self.session.set_survey_properties(survey_id, properties)
+
+    def update_survey(
+        self,
+        survey_id: int,
+        survey: Survey,
+    ) -> dict[str, bool]:
+        """Update properties of a survey.
+
+        Type-safe alternative to :meth:`set_survey_properties` that derives the
+        properties to update from a :class:`~citric.objects.Survey` object via
+        its :meth:`~citric.objects.Survey.to_dict` method.
+
+        Calls :rpc_method:`set_survey_properties`.
+
+        Args:
+            survey_id: ID of the survey to update.
+            survey: Survey object whose properties will be applied.
+
+        Returns:
+            Mapping of property names to whether they were set successfully.
+
+        .. versionadded:: NEXT_VERSION
+        """
+        return self.session.set_survey_properties(survey_id, survey.to_dict())
 
     def upload_file_object(
         self,

--- a/src/citric/objects/__init__.py
+++ b/src/citric/objects/__init__.py
@@ -2,11 +2,15 @@
 
 from ._participant import Participant, to_yes_no
 from ._question import AnswerOption, Question, QuestionL10n
+from ._survey import QuestionGroup, Survey, SurveyL10n
 
 __all__ = [
     "AnswerOption",
     "Participant",
     "Question",
+    "QuestionGroup",
     "QuestionL10n",
+    "Survey",
+    "SurveyL10n",
     "to_yes_no",
 ]

--- a/src/citric/objects/_question.py
+++ b/src/citric/objects/_question.py
@@ -220,10 +220,12 @@ def _add_base_question_fields(
     gid: str,
     question: Question,
     order: int,
+    *,
+    sid: str = "0",
 ) -> None:
     _add_val(row, "qid", str(qid))
     _add_val(row, "parent_qid", str(parent_qid))
-    _add_val(row, "sid", "0")
+    _add_val(row, "sid", sid)
     _add_val(row, "gid", gid)
     _add_val(row, "type", question.type)
     _add_val(row, "title", question.title)

--- a/src/citric/objects/_survey.py
+++ b/src/citric/objects/_survey.py
@@ -1,0 +1,373 @@
+"""Survey object for generating LimeSurvey LSS import files."""
+
+from __future__ import annotations
+
+import io
+import xml.etree.ElementTree as ET  # noqa: S405
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from citric import enums
+from citric.objects._question import (
+    _ANSWER_FIELDS,
+    _ANSWER_L10N_FIELDS,
+    _ATTR_FIELDS,
+    _L10N_FIELDS,
+    _QUESTION_FIELDS,
+    _SUBQUESTION_FIELDS,
+    DEFAULT_DB_VERSION,
+    Question,
+    _add_base_question_fields,
+    _add_fields,
+    _add_l10n_row,
+    _add_val,
+)
+
+if TYPE_CHECKING:
+    from citric import types
+
+_SURVEY_FIELDS = [
+    "sid",
+    "gsid",
+    "admin",
+    "expires",
+    "startdate",
+    "adminemail",
+    "anonymized",
+    "faxto",
+    "format",
+    "savetimings",
+    "template",
+    "language",
+    "additional_languages",
+    "datestamp",
+    "usecookie",
+    "allowregister",
+    "allowsave",
+    "autonumber_start",
+    "autoredirect",
+    "allowprev",
+    "printanswers",
+    "ipaddr",
+    "ipanonymize",
+    "refurl",
+    "showsurveypolicynotice",
+    "publicstatistics",
+    "publicgraphs",
+    "listpublic",
+    "htmlemail",
+    "sendconfirmation",
+    "tokenanswerspersistence",
+    "assessments",
+    "usecaptcha",
+    "usetokens",
+    "bounce_email",
+    "attributedescriptions",
+    "emailresponseto",
+    "emailnotificationto",
+    "tokenlength",
+    "showxquestions",
+    "showgroupinfo",
+    "shownoanswer",
+    "showqnumcode",
+    "bouncetime",
+    "bounceprocessing",
+    "bounceaccounttype",
+    "bounceaccounthost",
+    "bounceaccountpass",
+    "bounceaccountencryption",
+    "bounceaccountuser",
+    "showwelcomeinfo",
+    "showprogress",
+    "questionindex",
+    "navigationdelay",
+    "nokeyboard",
+    "alloweditaftercompletion",
+    "googleanalyticsstyle",
+    "googleanalyticsapikey",
+    "tokenencryptionoptions",
+]
+
+_SURVEY_L10N_FIELDS = [
+    "surveyls_survey_id",
+    "surveyls_language",
+    "surveyls_title",
+    "surveyls_description",
+    "surveyls_welcometext",
+    "surveyls_endtext",
+    "surveyls_policy_notice",
+    "surveyls_policy_error",
+    "surveyls_policy_notice_label",
+    "surveyls_url",
+    "surveyls_urldescription",
+    "surveyls_email_invite_subj",
+    "surveyls_email_invite",
+    "surveyls_email_remind_subj",
+    "surveyls_email_remind",
+    "surveyls_email_register_subj",
+    "surveyls_email_register",
+    "surveyls_email_confirm_subj",
+    "surveyls_email_confirm",
+    "surveyls_dateformat",
+    "surveyls_attributecaptions",
+    "email_admin_notification_subj",
+    "email_admin_notification",
+    "email_admin_responses_subj",
+    "email_admin_responses",
+    "surveyls_numberformat",
+    "attachments",
+]
+
+_GROUP_FIELDS = [
+    "gid",
+    "sid",
+    "group_name",
+    "group_order",
+    "description",
+    "language",
+    "randomization_group",
+    "grelevance",
+]
+
+
+@dataclass(slots=True)
+class SurveyL10n:
+    """Localization data for a survey in one language."""
+
+    title: str = ""
+    description: str = ""
+    welcometext: str = ""
+    endtext: str = ""
+
+
+@dataclass(slots=True)
+class QuestionGroup:
+    """A LimeSurvey question group."""
+
+    title: str
+    description: str = ""
+    questions: list[Question] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Survey:
+    """A LimeSurvey survey that can export itself as an LSS file."""
+
+    language: str
+    title: str
+    l10ns: dict[str, SurveyL10n] = field(default_factory=dict)
+    admin: str = "Administrator"
+    adminemail: str = "admin@example.com"
+    format: str = "G"
+    groups: list[QuestionGroup] = field(default_factory=list)
+
+    def to_dict(self) -> types.SurveyProperties:
+        """Return survey properties suitable for :meth:`~citric.Client.update_survey`.
+
+        .. note::
+
+           The survey :attr:`title` is not included here because
+           ``set_survey_properties`` does not expose it as a directly settable
+           property. To set the title, import the survey via
+           :meth:`~citric.Client.import_survey` using :meth:`to_lss`.
+
+        Returns:
+            A :class:`~citric.types.SurveyProperties` mapping with the fields
+            that can be updated via the RPC ``set_survey_properties`` method.
+        """
+        return {
+            "language": self.language,
+            "admin": self.admin,
+            "admin_email": self.adminemail,
+            "format": enums.NewSurveyType(self.format),
+        }
+
+    def to_lss(self, *, db_version: int = DEFAULT_DB_VERSION) -> io.BytesIO:
+        """Generate an LSS XML stream for use with client.import_survey().
+
+        Returns:
+            A BytesIO object containing the LSS-format XML.
+        """
+        doc = ET.Element("document")
+        ET.SubElement(doc, "LimeSurveyDocType").text = "Survey"
+        ET.SubElement(doc, "DBVersion").text = str(db_version)
+
+        langs_elem = ET.SubElement(doc, "languages")
+        ET.SubElement(langs_elem, "language").text = self.language
+        for lang in self.l10ns:
+            if lang != self.language:
+                ET.SubElement(langs_elem, "language").text = lang
+
+        self._build_surveys(doc)
+        self._build_surveys_languagesettings(doc)
+        self._build_groups(doc)
+        self._build_questions(doc)
+        self._build_subquestions(doc)
+        self._build_question_l10ns(doc)
+        self._build_question_attributes(doc)
+        self._build_answers(doc)
+
+        ET.indent(doc)
+        buffer = io.BytesIO()
+        ET.ElementTree(doc).write(buffer, encoding="UTF-8", xml_declaration=True)
+        buffer.seek(0)
+        return buffer
+
+    def _build_surveys(self, doc: ET.Element) -> None:
+        elem = ET.SubElement(doc, "surveys")
+        _add_fields(elem, _SURVEY_FIELDS)
+        rows_elem = ET.SubElement(elem, "rows")
+        row = ET.SubElement(rows_elem, "row")
+        _add_val(row, "sid", "1")
+        _add_val(row, "gsid", "1")
+        _add_val(row, "admin", self.admin)
+        _add_val(row, "adminemail", self.adminemail)
+        _add_val(row, "language", self.language)
+        _add_val(row, "format", self.format)
+
+    def _build_surveys_languagesettings(self, doc: ET.Element) -> None:
+        elem = ET.SubElement(doc, "surveys_languagesettings")
+        _add_fields(elem, _SURVEY_L10N_FIELDS)
+        rows_elem = ET.SubElement(elem, "rows")
+
+        base_l10n = self.l10ns.get(self.language, SurveyL10n(title=self.title))
+        self._add_survey_l10n_row(rows_elem, self.language, base_l10n)
+
+        for lang, l10n in self.l10ns.items():
+            if lang != self.language:
+                self._add_survey_l10n_row(rows_elem, lang, l10n)
+
+    def _add_survey_l10n_row(
+        self, rows_elem: ET.Element, lang: str, l10n: SurveyL10n
+    ) -> None:
+        row = ET.SubElement(rows_elem, "row")
+        _add_val(row, "surveyls_survey_id", "1")
+        _add_val(row, "surveyls_language", lang)
+        _add_val(row, "surveyls_title", l10n.title or self.title)
+        _add_val(row, "surveyls_description", l10n.description)
+        _add_val(row, "surveyls_welcometext", l10n.welcometext)
+        _add_val(row, "surveyls_endtext", l10n.endtext)
+
+    def _build_groups(self, doc: ET.Element) -> None:
+        elem = ET.SubElement(doc, "groups")
+        _add_fields(elem, _GROUP_FIELDS)
+        rows_elem = ET.SubElement(elem, "rows")
+        for i, group in enumerate(self.groups, start=1):
+            row = ET.SubElement(rows_elem, "row")
+            _add_val(row, "gid", str(i))
+            _add_val(row, "sid", "1")
+            _add_val(row, "group_name", group.title)
+            _add_val(row, "group_order", str(i))
+            _add_val(row, "description", group.description)
+            _add_val(row, "language", self.language)
+            _add_val(row, "randomization_group", "")
+            _add_val(row, "grelevance", "1")
+
+    def _build_questions(self, doc: ET.Element) -> None:
+        questions_elem = ET.SubElement(doc, "questions")
+        _add_fields(questions_elem, _QUESTION_FIELDS)
+        rows_elem = ET.SubElement(questions_elem, "rows")
+
+        qid = 1
+        for gid, group in enumerate(self.groups, start=1):
+            for order, question in enumerate(group.questions, start=1):
+                row = ET.SubElement(rows_elem, "row")
+                _add_base_question_fields(
+                    row,
+                    qid,
+                    0,
+                    str(gid),
+                    question,
+                    order,
+                    sid="1",
+                )
+                qid += 1
+
+    def _build_subquestions(self, doc: ET.Element) -> None:
+        subquestions_elem = ET.SubElement(doc, "subquestions")
+        _add_fields(subquestions_elem, _SUBQUESTION_FIELDS)
+        rows_elem = ET.SubElement(subquestions_elem, "rows")
+
+        total_questions = sum(len(g.questions) for g in self.groups)
+        qid = 1
+        sqid = total_questions + 1
+        l10n_id = 1
+        for gid, group in enumerate(self.groups, start=1):
+            for question in group.questions:
+                for i, sq in enumerate(question.subquestions, start=1):
+                    for lang, l10n in sq.l10ns.items():
+                        row = ET.SubElement(rows_elem, "row")
+                        _add_base_question_fields(
+                            row, sqid, qid, str(gid), sq, i, sid="1"
+                        )
+                        _add_val(row, "id", str(l10n_id))
+                        _add_val(row, "question", l10n.question or None)
+                        _add_val(row, "help", l10n.help or None)
+                        _add_val(row, "script", l10n.script or None)
+                        _add_val(row, "language", lang)
+                        l10n_id += 1
+                    sqid += 1
+                qid += 1
+
+    def _build_question_l10ns(self, doc: ET.Element) -> None:
+        l10ns_elem = ET.SubElement(doc, "question_l10ns")
+        _add_fields(l10ns_elem, _L10N_FIELDS)
+        rows_elem = ET.SubElement(l10ns_elem, "rows")
+
+        qid = 1
+        row_id = 1
+        for group in self.groups:
+            for question in group.questions:
+                for lang, l10n in question.l10ns.items():
+                    _add_l10n_row(
+                        rows_elem, row_id=row_id, qid=qid, lang=lang, l10n=l10n
+                    )
+                    row_id += 1
+                qid += 1
+
+    def _build_question_attributes(self, doc: ET.Element) -> None:
+        attrs_elem = ET.SubElement(doc, "question_attributes")
+        _add_fields(attrs_elem, _ATTR_FIELDS)
+        rows_elem = ET.SubElement(attrs_elem, "rows")
+        qid = 1
+        for group in self.groups:
+            for question in group.questions:
+                for attr_name, attr_value in question.attributes.items():
+                    row = ET.SubElement(rows_elem, "row")
+                    _add_val(row, "qid", str(qid))
+                    _add_val(row, "attribute", attr_name)
+                    _add_val(row, "value", attr_value or None)
+                    _add_val(row, "language", None)
+                qid += 1
+
+    def _build_answers(self, doc: ET.Element) -> None:
+        answers_elem = ET.SubElement(doc, "answers")
+        _add_fields(answers_elem, _ANSWER_FIELDS)
+        answers_rows = ET.SubElement(answers_elem, "rows")
+
+        answer_l10ns_elem = ET.SubElement(doc, "answer_l10ns")
+        _add_fields(answer_l10ns_elem, _ANSWER_L10N_FIELDS)
+        answer_l10ns_rows = ET.SubElement(answer_l10ns_elem, "rows")
+
+        qid = 1
+        aid = 1
+        l10n_id = 1
+        for group in self.groups:
+            for question in group.questions:
+                for option in question.answer_options:
+                    row = ET.SubElement(answers_rows, "row")
+                    _add_val(row, "aid", str(aid))
+                    _add_val(row, "qid", str(qid))
+                    _add_val(row, "code", option.code)
+                    _add_val(row, "sortorder", str(option.sort_order))
+                    _add_val(row, "assessment_value", str(option.assessment_value))
+                    _add_val(row, "scale_id", str(option.scale_id))
+                    for lang, answer_text in option.l10ns.items():
+                        l10n_row = ET.SubElement(answer_l10ns_rows, "row")
+                        _add_val(l10n_row, "id", str(l10n_id))
+                        _add_val(l10n_row, "aid", str(aid))
+                        _add_val(l10n_row, "answer", answer_text or None)
+                        _add_val(l10n_row, "language", lang)
+                        l10n_id += 1
+                    aid += 1
+                qid += 1

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -1071,7 +1071,7 @@ def file_upload_question(
     return question
 
 
-def assert_uploaded_files(  # noqa: D103
+def assert_uploaded_files(
     files: Iterable[tuple[ReadableFile, FileUploadResult, bytes]],
     subtests: pytest.Subtests,
 ) -> None:
@@ -1084,7 +1084,7 @@ def assert_uploaded_files(  # noqa: D103
             assert down["content"].read() == content
 
 
-def assert_downloaded_files(  # noqa: D103
+def assert_downloaded_files(
     files: Iterable[tuple[Path, FileUploadResult, bytes]],
     subtests: pytest.Subtests,
 ) -> None:

--- a/tests/objects/test_question.py
+++ b/tests/objects/test_question.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET  # noqa: S405
+import xml.etree.ElementTree as ET
 
 from citric.objects import AnswerOption, Question, QuestionL10n
 
 
 def _parse(q: Question) -> ET.Element:
-    return ET.parse(q.to_lsq()).getroot()  # noqa: S314
+    return ET.parse(q.to_lsq()).getroot()
 
 
 def test_document_metadata():
@@ -33,7 +33,7 @@ def test_custom_db_version():
         type="T",
         l10ns={"en": QuestionL10n(question="Hello")},
     )
-    root = ET.parse(q.to_lsq(db_version=999)).getroot()  # noqa: S314
+    root = ET.parse(q.to_lsq(db_version=999)).getroot()
     assert root.findtext("DBVersion") == "999"
 
 

--- a/tests/objects/test_survey.py
+++ b/tests/objects/test_survey.py
@@ -1,0 +1,296 @@
+"""Unit tests for Survey LSS generation."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from citric.objects import (
+    AnswerOption,
+    Question,
+    QuestionGroup,
+    QuestionL10n,
+    Survey,
+    SurveyL10n,
+)
+
+
+def _parse(s: Survey) -> ET.Element:
+    return ET.parse(s.to_lss()).getroot()
+
+
+def test_survey_metadata():
+    s = Survey(
+        language="en",
+        title="Test Survey",
+    )
+    root = _parse(s)
+    assert root.tag == "document"
+    assert root.findtext("LimeSurveyDocType") == "Survey"
+    assert root.findtext("DBVersion") == "641"
+
+
+def test_survey_metadata_custom_db_version():
+    s = Survey(language="en", title="Test Survey")
+    root = ET.parse(s.to_lss(db_version=700)).getroot()
+    assert root.findtext("DBVersion") == "700"
+
+
+def test_survey_base_language_in_languages():
+    s = Survey(language="en", title="Test Survey")
+    root = _parse(s)
+    langs = [e.text for e in root.findall("languages/language")]
+    assert langs == ["en"]
+
+
+def test_survey_admin_fields():
+    s = Survey(
+        language="en",
+        title="Test Survey",
+        admin="Jane Doe",
+        adminemail="jane@example.com",
+        format="S",
+    )
+    root = _parse(s)
+    survey_row = root.find("surveys/rows/row")
+    assert survey_row is not None
+    assert survey_row.findtext("admin") == "Jane Doe"
+    assert survey_row.findtext("adminemail") == "jane@example.com"
+    assert survey_row.findtext("format") == "S"
+
+
+def test_survey_languagesettings_base():
+    s = Survey(language="en", title="Welcome Survey")
+    root = _parse(s)
+    rows = root.findall("surveys_languagesettings/rows/row")
+    assert len(rows) == 1
+    assert rows[0].findtext("surveyls_language") == "en"
+    assert rows[0].findtext("surveyls_title") == "Welcome Survey"
+
+
+def test_survey_languagesettings_with_l10n():
+    s = Survey(
+        language="en",
+        title="My Survey",
+        l10ns={
+            "en": SurveyL10n(
+                title="My Survey",
+                description="A description",
+                welcometext="Welcome!",
+                endtext="Thanks!",
+            ),
+            "fr": SurveyL10n(title="Mon Enquête", description="Une description"),
+        },
+    )
+    root = _parse(s)
+
+    # Both languages should appear in the <languages> block
+    langs = {e.text for e in root.findall("languages/language")}
+    assert langs == {"en", "fr"}
+
+    rows = root.findall("surveys_languagesettings/rows/row")
+    assert len(rows) == 2
+
+    by_lang = {r.findtext("surveyls_language"): r for r in rows}
+    assert by_lang["en"].findtext("surveyls_title") == "My Survey"
+    assert by_lang["en"].findtext("surveyls_description") == "A description"
+    assert by_lang["en"].findtext("surveyls_welcometext") == "Welcome!"
+    assert by_lang["en"].findtext("surveyls_endtext") == "Thanks!"
+    assert by_lang["fr"].findtext("surveyls_title") == "Mon Enquête"
+
+
+def test_survey_l10n_falls_back_to_survey_title():
+    """If base language is not in l10ns, the survey title is used."""
+    s = Survey(
+        language="en",
+        title="Fallback Title",
+        l10ns={"fr": SurveyL10n(title="Titre de secours")},
+    )
+    root = _parse(s)
+    rows = root.findall("surveys_languagesettings/rows/row")
+    by_lang = {r.findtext("surveyls_language"): r for r in rows}
+    assert by_lang["en"].findtext("surveyls_title") == "Fallback Title"
+
+
+def test_survey_groups_and_questions():
+    q1 = Question(
+        title="Q1",
+        type="T",
+        l10ns={"en": QuestionL10n(question="Q1?")},
+    )
+    group = QuestionGroup(title="Group 1", questions=[q1])
+    s = Survey(language="en", title="Test Survey", groups=[group])
+    root = _parse(s)
+
+    group_rows = root.findall("groups/rows/row")
+    assert len(group_rows) == 1
+    assert group_rows[0].findtext("group_name") == "Group 1"
+
+    question_rows = root.findall("questions/rows/row")
+    assert len(question_rows) == 1
+    assert question_rows[0].findtext("title") == "Q1"
+
+
+def test_survey_multiple_groups_and_questions():
+    q1 = Question(title="Q1", type="T", l10ns={"en": QuestionL10n(question="Q1?")})
+    q2 = Question(title="Q2", type="T", l10ns={"en": QuestionL10n(question="Q2?")})
+    q3 = Question(title="Q3", type="N", l10ns={"en": QuestionL10n(question="Q3?")})
+    groups = [
+        QuestionGroup(title="Group A", questions=[q1, q2]),
+        QuestionGroup(title="Group B", questions=[q3]),
+    ]
+    s = Survey(language="en", title="Test Survey", groups=groups)
+    root = _parse(s)
+
+    group_rows = root.findall("groups/rows/row")
+    assert len(group_rows) == 2
+    assert group_rows[0].findtext("group_name") == "Group A"
+    assert group_rows[1].findtext("group_name") == "Group B"
+
+    question_rows = root.findall("questions/rows/row")
+    assert len(question_rows) == 3
+    titles = [r.findtext("title") for r in question_rows]
+    assert titles == ["Q1", "Q2", "Q3"]
+
+    # Each question row should reference sid=1
+    for row in question_rows:
+        assert row.findtext("sid") == "1"
+
+
+def test_survey_question_l10ns():
+    q = Question(
+        title="Q1",
+        type="T",
+        l10ns={
+            "en": QuestionL10n(question="What is your name?", help="Enter your name"),
+            "fr": QuestionL10n(question="Quel est votre nom?"),
+        },
+    )
+    s = Survey(
+        language="en",
+        title="Test Survey",
+        groups=[QuestionGroup(title="G1", questions=[q])],
+    )
+    root = _parse(s)
+
+    l10n_rows = root.findall("question_l10ns/rows/row")
+    assert len(l10n_rows) == 2
+    by_lang = {r.findtext("language"): r for r in l10n_rows}
+    assert by_lang["en"].findtext("question") == "What is your name?"
+    assert by_lang["en"].findtext("help") == "Enter your name"
+    assert by_lang["fr"].findtext("question") == "Quel est votre nom?"
+
+
+def test_survey_with_subquestions():
+    sq1 = Question(
+        title="SQ1",
+        type="T",
+        l10ns={"en": QuestionL10n(question="Row 1")},
+    )
+    sq2 = Question(
+        title="SQ2",
+        type="T",
+        l10ns={"en": QuestionL10n(question="Row 2")},
+    )
+    q = Question(
+        title="Q1",
+        type="F",
+        l10ns={"en": QuestionL10n(question="Matrix question")},
+        subquestions=[sq1, sq2],
+    )
+    s = Survey(
+        language="en",
+        title="Test Survey",
+        groups=[QuestionGroup(title="G1", questions=[q])],
+    )
+    root = _parse(s)
+
+    sq_rows = root.findall("subquestions/rows/row")
+    assert len(sq_rows) == 2
+    titles = [r.findtext("title") for r in sq_rows]
+    assert titles == ["SQ1", "SQ2"]
+
+    # All subquestion rows should reference sid=1
+    for row in sq_rows:
+        assert row.findtext("sid") == "1"
+
+
+def test_survey_with_answer_options():
+    opt_a = AnswerOption(code="A", l10ns={"en": "Option A"}, sort_order=1)
+    opt_b = AnswerOption(code="B", l10ns={"en": "Option B"}, sort_order=2)
+    q = Question(
+        title="Q1",
+        type="L",
+        l10ns={"en": QuestionL10n(question="Pick one")},
+        answer_options=[opt_a, opt_b],
+    )
+    s = Survey(
+        language="en",
+        title="Test Survey",
+        groups=[QuestionGroup(title="G1", questions=[q])],
+    )
+    root = _parse(s)
+
+    answer_rows = root.findall("answers/rows/row")
+    assert len(answer_rows) == 2
+    codes = [r.findtext("code") for r in answer_rows]
+    assert codes == ["A", "B"]
+    assert answer_rows[0].findtext("sortorder") == "1"
+
+    l10n_rows = root.findall("answer_l10ns/rows/row")
+    assert len(l10n_rows) == 2
+    assert l10n_rows[0].findtext("answer") == "Option A"
+    assert l10n_rows[1].findtext("answer") == "Option B"
+
+
+def test_survey_answer_options_multilingual():
+    opt = AnswerOption(
+        code="Y",
+        l10ns={"en": "Yes", "fr": "Oui"},
+    )
+    q = Question(
+        title="Q1",
+        type="L",
+        l10ns={"en": QuestionL10n(question="Yes/No?")},
+        answer_options=[opt],
+    )
+    s = Survey(
+        language="en",
+        title="Test Survey",
+        groups=[QuestionGroup(title="G1", questions=[q])],
+    )
+    root = _parse(s)
+
+    l10n_rows = root.findall("answer_l10ns/rows/row")
+    assert len(l10n_rows) == 2
+    by_lang = {r.findtext("language"): r for r in l10n_rows}
+    assert by_lang["en"].findtext("answer") == "Yes"
+    assert by_lang["fr"].findtext("answer") == "Oui"
+
+
+def test_survey_empty_groups():
+    s = Survey(language="en", title="Empty Survey", groups=[])
+    root = _parse(s)
+    assert root.findall("groups/rows/row") == []
+    assert root.findall("questions/rows/row") == []
+    assert root.findall("subquestions/rows/row") == []
+    assert root.findall("question_l10ns/rows/row") == []
+    assert root.findall("answers/rows/row") == []
+    assert root.findall("answer_l10ns/rows/row") == []
+
+
+def test_survey_group_description():
+    group = QuestionGroup(title="My Group", description="Group description")
+    s = Survey(language="en", title="Test Survey", groups=[group])
+    root = _parse(s)
+    row = root.find("groups/rows/row")
+    assert row is not None
+    assert row.findtext("description") == "Group description"
+
+
+@pytest.mark.parametrize("db_version", [500, 641, 700])
+def test_survey_custom_db_version(db_version: int):
+    s = Survey(language="en", title="Test")
+    root = ET.parse(s.to_lss(db_version=db_version)).getroot()
+    assert root.findtext("DBVersion") == str(db_version)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from citric.client import Client, ServerVersion
+from citric.objects import Survey
 from citric.session import Session
 
 if sys.version_info >= (3, 12):
@@ -79,3 +80,16 @@ def test_invite_participants_unknown_status(client: MockClient):
 def test_parse_server_version(raw: str, parsed: tuple):
     """Test server version parsing."""
     assert ServerVersion.parse(raw) == parsed
+
+
+def test_update_survey(client: MockClient):
+    """update_survey delegates to set_survey_properties via Survey.to_dict()."""
+    survey = Survey(
+        language="de",
+        title="Test",
+        admin="Jane",
+        adminemail="jane@example.com",
+        format="S",
+    )
+    result: dict[str, Any] = client.update_survey(123, survey)
+    assert result["params"][1] == survey.to_dict()


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Links

- Closes https://github.com/edgarrmondragon/citric/issues/1119
- Closes https://github.com/edgarrmondragon/citric/issues/1679

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Introduce a composable Survey object model for generating LimeSurvey LSS files and updating survey properties via the client API.

New Features:
- Add Survey, SurveyL10n and QuestionGroup objects for representing surveys and exporting them as LimeSurvey LSS XML.
- Expose a type-safe Client.update_survey method that applies properties from a Survey object.

Bug Fixes:
- Correct typos in SurveyProperties keys (savetiming→savetimings, datesstamp→datestamp) to match the LimeSurvey API.

Enhancements:
- Export new survey-related objects from the citric.objects package for easier consumption.
- Improve Sphinx configuration to ignore an internal Question class reference that cannot be resolved.

Tests:
- Add comprehensive tests for Survey LSS generation covering metadata, localization, groups, questions, subquestions, and answer options.
- Add a client test to verify update_survey delegates to set_survey_properties using Survey.to_dict().