### PR TITLE
ci: Test on Python 3.14 free-threaded

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,9 @@ jobs:
         - python-version: "3.14"
           os: ubuntu-24.04
 
+        - python-version: "3.14t"
+          os: ubuntu-24.04
+
         - python-version: "3.13"
           os: ubuntu-24.04
 
@@ -210,6 +213,10 @@ jobs:
           database: postgres
 
         - python-version: "3.13"
+          image_tag: "6-apache"
+          database: postgres
+
+        - python-version: "3.14t"
           image_tag: "6-apache"
           database: postgres
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ nox.options.reuse_venv = "yes"
 
 package = "citric"
 
-python_versions = nox.project.python_versions(PYPROJECT)
+python_versions = [*nox.project.python_versions(PYPROJECT), "3.14t"]
 
 locations = "src", "tests", "docs/conf.py"
 
@@ -35,9 +35,13 @@ locations = "src", "tests", "docs/conf.py"
 @nox.parametrize("constraints", ["highest", "lowest-direct"])
 def tests(session: nox.Session, constraints: str) -> None:
     """Execute pytest tests and compute coverage."""
+    env = {"COVERAGE_CORE": "sysmon"}
     install_args = [".", "--group=test"]
     if constraints == "lowest-direct":
         install_args.append("--resolution=lowest-direct")
+
+    if session.python.endswith("t"):
+        env["PYTHON_GIL"] = "0"
 
     session.install(*install_args)
 
@@ -49,7 +53,7 @@ def tests(session: nox.Session, constraints: str) -> None:
         "-m",
         "not integration_test",
         *session.posargs,
-        env={"COVERAGE_CORE": "sysmon"},
+        env=env,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: Free Threading :: 4 - Resilient",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sysconfig
 from importlib.metadata import version
 
 import pytest
@@ -131,7 +132,12 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
             f"LimeSurvey image tag: {config.getoption('--limesurvey-image-tag')}"
         )
 
-    return env_vars + dependencies + integration
+    lines = env_vars + dependencies + integration
+
+    if sysconfig.get_config_var("Py_GIL_DISABLED"):
+        lines.append("free-threaded Python build")
+
+    return lines
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Add support and CI coverage for running tests on Python 3.14 free-threaded builds and advertise compatibility in packaging metadata.

Enhancements:
- Include Python 3.14 free-threaded in nox session Python versions and configure environment flags for running tests under free-threaded interpreters.
- Report free-threaded Python builds in pytest headers for easier visibility during test runs.
- Advertise free-threaded Python resilience support in project classifiers.

CI:
- Extend GitHub Actions test matrix to run unit and integration tests on Python 3.14 free-threaded builds.