### PR TITLE
ci: Stop uploading attestations to release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,3 @@ jobs:
         id: attest
         with:
           subject-path: "./dist/citric*"
-      - name: Upload attestation bundle to release
-        env:
-          FILE_PATH: ${{ steps.attest.outputs.bundle-path }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
-        run: gh release upload "$TAG" "$FILE_PATH#attestations.intoto.jsonl"

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -76,13 +76,14 @@ jobs:
       run: |
         url=$(gh release create "$LATEST" \
           --draft \
+          --title ${LATEST} \
           --notes-file ".changes/${LATEST}.md")
         echo "url=${url}" >> "$GITHUB_OUTPUT"
 
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: generate-token
       with:
-        app-id: ${{ vars.APP_ID }}
+        client-id: ${{ vars.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Get GitHub App User ID

--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         url=$(gh release create "$LATEST" \
           --draft \
-          --title ${LATEST} \
+          --title "${LATEST}" \
           --notes-file ".changes/${LATEST}.md")
         echo "url=${url}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/limesurvey-tags.yml
+++ b/.github/workflows/limesurvey-tags.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: generate-token
       with:
-        app-id: ${{ vars.APP_ID }}
+        client-id: ${{ vars.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
     - name: Get GitHub App User ID


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

They're already available in https://github.com/edgarrmondragon/citric/attestations.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Update CI workflows to stop attaching attestation bundles to GitHub releases and to adjust GitHub App token configuration.

Build:
- Remove step that uploads attestations bundle as a release asset in the build workflow.
- Set the release title explicitly when creating draft releases in the gen-release-pr workflow.
- Switch GitHub App token configuration from app-id to client-id in release and LimeSurvey tagging workflows.