### PR TITLE
ci: Use explicit app token permissions

### DIFF
--- a/.github/workflows/gen-release-pr.yml
+++ b/.github/workflows/gen-release-pr.yml
@@ -85,6 +85,8 @@ jobs:
       with:
         client-id: ${{ vars.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        permission-contents: write
+        permission-pull-requests: write
 
     - name: Get GitHub App User ID
       id: get-user-id

--- a/.github/workflows/limesurvey-tags.yml
+++ b/.github/workflows/limesurvey-tags.yml
@@ -45,6 +45,8 @@ jobs:
       with:
         client-id: ${{ vars.APP_ID }}
         private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        permission-contents: write
+        permission-pull-requests: write
 
     - name: Get GitHub App User ID
       id: get-user-id


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA, as reported by zizmor

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Specify explicit GitHub App token permissions for relevant workflows

CI:
- Set explicit contents and pull-requests write permissions for the GitHub App token in the gen-release-pr workflow
- Set explicit contents and pull-requests write permissions for the GitHub App token in the limesurvey-tags workflow