### PR TITLE
feat: Support LimeSurvey 7 and update client to handle changes to the `fieldname` format

### DIFF
--- a/.changes/unreleased/Added-20260602-210914.yaml
+++ b/.changes/unreleased/Added-20260602-210914.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Support LimeSurvey 7 and update client to handle changes to the `fieldname` format
+time: 2026-06-02T21:09:14.631745-06:00
+custom:
+    Issue: "1774"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ release = citric.__version__
 # -- General configuration -------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+suppress_warnings = [
+    "ref.python",  # https://github.com/sphinx-doc/sphinx/issues/14223
+]
+
 extensions = [
     # Built-in extensions
     "sphinx.ext.autodoc",

--- a/src/citric/__init__.py
+++ b/src/citric/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib import metadata
 
 from citric import objects
-from citric.client import Client
+from citric.client import Client, ServerVersion
 from citric.rest import RESTClient
 
 __version__: str = metadata.version("citric")
@@ -13,4 +13,4 @@ __version__: str = metadata.version("citric")
 
 del annotations, metadata  # noqa: RUF067
 
-__all__ = ["Client", "RESTClient", "objects"]
+__all__ = ["Client", "RESTClient", "ServerVersion", "objects"]

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -5,15 +5,11 @@ from __future__ import annotations
 import base64
 import datetime
 import io
+import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import (  # noqa: UP035
-    IO,
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Type,
-)
+from typing import IO, TYPE_CHECKING, Any, Literal
 
 import requests
 
@@ -39,7 +35,72 @@ __all__ = [
     "Client",
 ]
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 EMAILS_SENT_STATUS_PATTERN: re.Pattern[str] = re.compile(r"(-?\d+) left to send")
+_SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9]\d*)"
+    r"\.(?P<minor>0|[1-9]\d*)"
+    r"\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9a-z-]+(?:\.[0-9a-z-]+)*))?"
+    r"(?:\+(?P<build>[0-9a-z-]+(?:\.[0-9a-z-]+)*))?$"
+)
+
+
+@dataclass
+class ServerVersion:
+    """A LimeSurvey server version.
+
+    .. versionadded:: NEXT_VERSION
+    """
+
+    major: int
+    minor: int = 0
+    patch: int = 0
+    prerelease: str | None = None
+    build: str | None = None
+
+    @classmethod
+    def _default(cls) -> ServerVersion:
+        return ServerVersion(0)
+
+    @classmethod
+    def parse(cls, version: str) -> ServerVersion:
+        """Parse a string into a server version object.
+
+        Args:
+            version: A semantic version string.
+
+        Returns:
+            A server version object.
+        """
+        if m := _SEMVER_RE.match(version.lower()):
+            return cls.from_dict(m.groupdict())
+
+        logger.warning(
+            "Could not detect server version from string '%s', defaulting to '0.0.0'",
+            version,
+        )
+        return cls._default()
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ServerVersion:
+        """Extract a dictionary's keys to create a server version object.
+
+        Args:
+            d: A dictionary with keys 'major', 'minor' and 'patch'.
+                Optionally 'prerelease' and 'build' keys can be included.
+
+        Returns:
+            A server version object.
+        """
+        return cls(
+            int(d["major"]),
+            int(d["minor"]),
+            int(d["patch"]),
+            d.get("prerelease"),
+            d.get("build"),
+        )
 
 
 class Client:  # noqa: PLR0904
@@ -80,6 +141,7 @@ class Client:  # noqa: PLR0904
             requests_session=requests_session or requests.session(),
             auth_plugin=auth_plugin,
         )
+        self.__server_version: ServerVersion | None = None
 
     def close(self) -> None:
         """Close client session."""
@@ -95,7 +157,7 @@ class Client:  # noqa: PLR0904
 
     def __exit__(
         self,
-        exc_type: Type[BaseException] | None,  # noqa: UP006
+        exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
@@ -106,6 +168,16 @@ class Client:  # noqa: PLR0904
     def session(self) -> Session:
         """Low-level RPC session."""
         return self.__session
+
+    @property
+    def server_version(self) -> ServerVersion:
+        """LimeSurvey server version (cached).
+
+        .. versionadded:: NEXT_VERSION
+        """
+        if self.__server_version is None:
+            self.__server_version = ServerVersion.parse(self.get_server_version())
+        return self.__server_version
 
     def get_fieldmap(self, survey_id: int) -> dict[str, Any]:
         """Get fieldmap for a survey.
@@ -337,31 +409,34 @@ class Client:  # noqa: PLR0904
         """
         return {q["title"]: q for q in self.list_questions(survey_id)}
 
-    @staticmethod
+    def _fieldname_from_question(self, question: types.QuestionsListElement) -> str:
+        return (
+            f"Q{question['qid']}"
+            if self.server_version.major >= 7  # noqa: PLR2004
+            else f"{question['sid']}X{question['gid']}X{question['qid']}"
+        )
+
     def _map_response_keys(
+        self,
         response_data: Mapping[str, Any],
         question_mapping: dict[str, types.QuestionsListElement],
     ) -> dict[str, Any]:
         """Convert response keys to LimeSurvey's internal representation.
+
+        In LimeSurvey 7+, the key format changed from '<SID>X<GID>X<QID>' to
+        'Q<QID>'.
 
         Args:
             response_data: The response mapping.
             question_mapping: A mapping of question titles to question dictionaries.
 
         Returns:
-            A new dictionary with the keys mapped to the <SID>X<GID>X<QID> format.
-
-        >>> keys = {"Q1": "foo", "Q2": "bar", "BAZ": "qux"}
-        >>> q1 = {"title": "Q1", "qid": 9, "gid": 7, "sid": 123}
-        >>> q2 = {"title": "Q2", "qid": 10, "gid": 7, "sid": 123}
-        >>> questions = {"Q1": q1, "Q2": q2}
-        >>> mapped_keys = Client._map_response_keys(keys, questions)
-        >>> mapped_keys
-        {'123X7X9': 'foo', '123X7X10': 'bar', 'BAZ': 'qux'}
+            A new dictionary with the keys mapped to the Q-style or <SID>X<GID>X<QID>
+            format.
         """
         return {
             (
-                "{sid}X{gid}X{qid}".format(**question_mapping[key])
+                self._fieldname_from_question(question_mapping[key])
                 if key in question_mapping
                 else key
             ): value
@@ -394,8 +469,8 @@ class Client:  # noqa: PLR0904
 
         Args:
             survey_id: Survey to add the response to.
-            response_data: Single response as a mapping from question codes of the form
-                <SID>X<GID>X<QID> to response values.
+            response_data: Single response as a mapping from fieldnames in the Q-style
+                or <SID>X<GID>X<QID> form to response values.
 
         Returns:
             ID of the new response.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -174,7 +174,7 @@ def survey_with_question_answers(
 @pytest.fixture(scope="session")
 def server_version(client: citric.Client) -> semver.Version:
     """Get the server version."""
-    return semver.Version.parse(client.get_server_version())
+    return semver.Version.parse(client.get_server_version().lower())
 
 
 @pytest.fixture

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
     from tests.fixtures import MailpitClient
 
 NEW_SURVEY_NAME = "New Survey"
+LS7_FIELDNAME_CHANGE_VERSION = "7.0.0-beta1"
 
 
 @pytest.fixture
@@ -89,7 +90,7 @@ def test_fieldmap(client: citric.Client, survey_id: int, subtests: pytest.Subtes
         with subtests.test(msg="test field", field=key):
             assert key == value["fieldname"]
             assert (
-                key == "{sid}X{gid}X{qid}".format(**value)
+                key == client._fieldname_from_question(value)
                 or not value["qid"]
                 or "_" in key
             )
@@ -1126,34 +1127,37 @@ def test_response_files(
     file_upload_question: QuestionsListElement,
     tmp_path: Path,
     faker: Faker,
+    server_version: semver.VersionInfo,
 ):
     """Test response files."""
     token = "T00000"
-    sid = file_upload_question["sid"]
-    gid = file_upload_question["gid"]
-    qid = file_upload_question["qid"]
-    field_name = f"{sid}X{gid}X{qid}"
+    fieldname = client._fieldname_from_question(file_upload_question)
 
     # Upload two files
     with io.BytesIO() as file:
         content1 = faker.zip()
         file.write(content1)
         file.seek(0)
-        result1 = client.upload_file_object(survey_id, field_name, "file1.zip", file)
+        result1 = client.upload_file_object(survey_id, fieldname, "file1.zip", file)
 
     with io.BytesIO() as file:
         content2 = faker.zip()
         file.write(content2)
         file.seek(0)
-        result2 = client.upload_file_object(survey_id, field_name, "file2.zip", file)
+        result2 = client.upload_file_object(survey_id, fieldname, "file2.zip", file)
 
     # Add a response
     response_files = [result1, result2]
+    fieldname_filecount = (
+        f"{fieldname}_filecount"
+        if server_version < LS7_FIELDNAME_CHANGE_VERSION
+        else f"{fieldname}_Cfilecount"
+    )
     responses = [
         {
             "token": token,
-            field_name: json.dumps(response_files),
-            f"{field_name}_filecount": len(response_files),
+            fieldname: json.dumps(response_files),
+            fieldname_filecount: len(response_files),
         },
     ]
     assert client.add_responses(survey_id, responses) == [1]
@@ -1200,11 +1204,9 @@ def test_file_upload(
     filepath.write_bytes(faker.zip())
 
     sid = file_upload_question["sid"]
-    gid = file_upload_question["gid"]
-    qid = file_upload_question["qid"]
-
     filename = "upload.zip"
-    result = client.upload_file(sid, f"{sid}X{gid}X{qid}", filepath, filename=filename)
+    fieldname = client._fieldname_from_question(file_upload_question)
+    result = client.upload_file(sid, fieldname, filepath, filename=filename)
     assert result["success"]
     assert result["size"] == pytest.approx(filepath.stat().st_size / 1000, rel=5e-2)
     assert result["name"] == filename
@@ -1225,10 +1227,8 @@ def test_file_upload_no_filename(
     filepath.write_bytes(faker.zip())
 
     sid = file_upload_question["sid"]
-    gid = file_upload_question["gid"]
-    qid = file_upload_question["qid"]
-
-    result_no_filename = client.upload_file(sid, f"{sid}X{gid}X{qid}", filepath)
+    fieldname = client._fieldname_from_question(file_upload_question)
+    result_no_filename = client.upload_file(sid, fieldname, filepath)
     assert result_no_filename["success"]
     assert result_no_filename["size"] == pytest.approx(
         filepath.stat().st_size / 1000,
@@ -1252,14 +1252,13 @@ def test_file_upload_invalid_extension(
     filepath.write_bytes(faker.zip())
 
     sid = file_upload_question["sid"]
-    gid = file_upload_question["gid"]
-    qid = file_upload_question["qid"]
+    fieldname = client._fieldname_from_question(file_upload_question)
 
     with pytest.raises(
         LimeSurveyStatusError,
         match="The extension abc is not valid\\. Valid extensions are: zip",
     ):
-        client.upload_file(sid, f"{sid}X{gid}X{qid}", filepath)
+        client.upload_file(sid, fieldname, filepath)
 
 
 @pytest.mark.integration_test

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
-from citric.client import Client
+from citric.client import Client, ServerVersion
 from citric.session import Session
 
 if sys.version_info >= (3, 12):
@@ -64,3 +64,18 @@ def test_invite_participants_unknown_status(client: MockClient):
     """Test invite_participants client method."""
     with pytest.raises(RuntimeError, match="Could not determine invitation status"):
         client.invite_participants(1)
+
+
+@pytest.mark.parametrize(
+    ("raw", "parsed"),
+    [
+        ("6.1.0", ServerVersion(6, 1)),
+        ("6.5.0-dev", ServerVersion(6, 5, prerelease="dev")),
+        ("7.0.0-beta1", ServerVersion(7, prerelease="beta1")),
+        ("7.0.0-RC1", ServerVersion(7, prerelease="rc1")),
+        ("NOMATCH", ServerVersion._default()),
+    ],
+)
+def test_parse_server_version(raw: str, parsed: tuple):
+    """Test server version parsing."""
+    assert ServerVersion.parse(raw) == parsed


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

On LimeSurvey 7+, the key format changed from `<Survey ID>X<Group ID>X<Question ID>` to `Q<Question ID>`.

Bisected to https://github.com/LimeSurvey/LimeSurvey/commit/18a68695f973320536bb6ab6feed97ce23a5512d#diff-532cf7aa0d91a79d219e249147cfb29e8d56cdfc691af5754a7587411c48ee0d.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Support LimeSurvey 7 by adapting client handling of fieldnames based on server version and updating tests and changelog accordingly.

New Features:
- Add automatic detection and parsing of LimeSurvey server version to drive version-dependent behavior.
- Introduce dynamic fieldname generation that supports both legacy <SID>X<GID>X<QID> and new Q<QID> formats.

Enhancements:
- Refactor response key mapping and file upload logic to use a shared fieldname helper that is aware of server version.

Documentation:
- Update changelog with the addition of LimeSurvey 7 support and fieldname format handling changes.

Tests:
- Extend integration and unit tests to cover version parsing, fieldname generation, and LimeSurvey 7-specific file upload behavior.