### PR TITLE
feat: LimeSurvey 7 is now supported

### DIFF
--- a/.changes/unreleased/Added-20260612-185322.yaml
+++ b/.changes/unreleased/Added-20260612-185322.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: LimeSurvey 7 is now supported
+time: 2026-06-12T18:53:22.183765-06:00
+custom:
+    Issue: "1779"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,12 +228,12 @@ jobs:
         # Test Limesurvey/LimeSurvey branches
         - python-version: "3.14"
           ref: refs/heads/develop-minor
-          context: https://github.com/martialblog/docker-limesurvey.git#master:6.0/apache
+          context: https://github.com/martialblog/docker-limesurvey.git#master:7.0/apache
           database: postgres
 
         - python-version: "3.14"
           ref: refs/heads/develop-major
-          context: https://github.com/martialblog/docker-limesurvey.git#master:6.0/apache
+          context: https://github.com/martialblog/docker-limesurvey.git#master:7.0/apache
           database: postgres
 
         - python-version: "3.14"
@@ -243,13 +243,8 @@ jobs:
 
         - python-version: "3.14"
           ref: refs/heads/master
-          context: https://github.com/martialblog/docker-limesurvey.git#master:6.0/apache
+          context: https://github.com/martialblog/docker-limesurvey.git#master:7.0/apache
           database: postgres
-
-        # - python-version: "3.12"
-        #   ref: refs/pull/3860/head
-        #   context: https://github.com/martialblog/docker-limesurvey.git#master:6.0/apache
-        #   database: postgres
 
     steps:
     - name: Check out the repository

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Integration tests are run against a LimeSurvey instance, and both PostgreSQL and
 ```{include} _partial/tags.md
 ```
 
-But also the latest 5.x and 6.x are tested continuously and are expected to work.
+But also the latest 5.x, 6.x and 7.x are tested continuously and are expected to work.
 
 ## How-to guides
 


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

## Links

- https://github.com/martialblog/docker-limesurvey/pull/297
- https://www.limesurvey.org/manual/LimeSurvey_7_Major_Version
- https://www.limesurvey.org/manual/LimeSurvey_7_Fieldname_Refactor

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

CI:
- Add a CI job configuration that runs tests against a LimeSurvey v7 Docker image with PostgreSQL on Python 3.14.

## Summary by Sourcery

Add continuous testing and documented support for LimeSurvey 7 across the project.

New Features:
- Declare LimeSurvey 7 as a supported LimeSurvey version.

CI:
- Update CI test matrix to run integration tests against the LimeSurvey 7 Docker image for key branches.

Documentation:
- Document that LimeSurvey 7.x is now tested continuously and expected to work.

Chores:
- Add a changelog entry recording LimeSurvey 7 support.