### PR TITLE
feat: Allow getting uploaded files by response ID

### DIFF
--- a/.changes/unreleased/Added-20260613-122908.yaml
+++ b/.changes/unreleased/Added-20260613-122908.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Allow getting uploaded files by response ID
+time: 2026-06-13T12:29:08.36017-06:00
+custom:
+    Issue: "1780"

--- a/code_samples/upload_s3.py
+++ b/code_samples/upload_s3.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 # start example
+import json
+
 import boto3
 from citric import Client
 
@@ -15,12 +17,14 @@ client = Client(
 )
 
 survey_id = 12345
+exported = json.loads(client.export_responses(survey_id, file_format="json"))
 
-# Get all uploaded files and upload them to S3
-for file in client.get_uploaded_file_objects(survey_id):
-    s3.upload_fileobj(
-        file["content"],
-        "my-s3-bucket",
-        f"uploads/sid={survey_id}/qid={file['meta']['question']['qid']}/{file['meta']['filename']}",
-    )
+# Get all uploaded files for all responses and upload them to S3
+for response in exported["responses"]:
+    for file in client.get_uploaded_file_objects(survey_id, response_id=response["id"]):
+        filename = (
+            f"uploads/sid={survey_id}/qid={file['meta']['question']['qid']}"
+            f"/{response['id']}/{file['meta']['filename']}"
+        )
+        s3.upload_fileobj(file["content"], "my-s3-bucket", filename)
 # end example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
   "deptry>=0.12",
   "requests-cache>=1.1",
   { include-group = "docs" },
+  { include-group = "samples" },
   { include-group = "test" },
   { include-group = "typing" },
 ]

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1255,8 +1255,8 @@ class Client:  # noqa: PLR0904
 
         Args:
             survey_id: Survey for which to download files.
-            token: Optional participant token to filter uploaded files.
-            response_id: Response ID.
+            token: Get the files uploaded by this response token.
+            response_id: Get the files uploaded to this response.
 
         Returns:
             Dictionary with uploaded files metadata.
@@ -1277,8 +1277,8 @@ class Client:  # noqa: PLR0904
 
         Args:
             survey_id: Survey for which to download files.
-            token: Participant token to filter uploaded files.
-            response_id: Response ID.
+            token: Get the files uploaded by this response token.
+            response_id: Get the files uploaded to this response.
 
         Yields:
             :class:`~citric.types.ReadableFile` dictionaries.
@@ -1309,8 +1309,8 @@ class Client:  # noqa: PLR0904
         Args:
             directory: Where to store the files.
             survey_id: Survey for which to download files.
-            token: Optional participant token to filter uploaded files.
-            response_id: Response ID.
+            token: Get the files uploaded by this response token.
+            response_id: Get the files uploaded to this response.
 
         Returns:
             List with the paths of downloaded files.

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1283,11 +1283,13 @@ class Client:  # noqa: PLR0904
         Yields:
             :class:`~citric.types.ReadableFile` dictionaries.
 
+        Example: `Get files uploaded to a survey and move them to S3 </how-to.html#get-files-uploaded-to-a-survey-and-move-them-to-s3>`__
+
         .. versionadded:: 0.0.13
         .. versionchanged:: 2.0.0
            Yield :class:`~citric.types.ReadableFile` dictionaries instead of
            dataclass instances.
-        """
+        """  # noqa: E501
         files_data = self.get_uploaded_files(survey_id, token, response_id)
         for file in files_data:
             yield {

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -1245,32 +1245,40 @@ class Client:  # noqa: PLR0904
         self,
         survey_id: int,
         token: str | None = None,
+        response_id: int | None = None,
     ) -> dict[str, types.EncodedFile]:
         """Get a dictionary of files uploaded in a survey response.
+
+        Either a token or a response ID is required.
 
         Calls :rpc_method:`get_uploaded_files`.
 
         Args:
             survey_id: Survey for which to download files.
             token: Optional participant token to filter uploaded files.
+            response_id: Response ID.
 
         Returns:
             Dictionary with uploaded files metadata.
 
         .. versionadded:: 0.0.5
         """
-        return self.session.get_uploaded_files(survey_id, token)
+        return self.session.get_uploaded_files(survey_id, token, response_id)
 
     def get_uploaded_file_objects(
         self,
         survey_id: int,
         token: str | None = None,
+        response_id: int | None = None,
     ) -> Generator[types.ReadableFile, None, None]:
         """Iterate over uploaded files in a survey response.
 
+        Either a token or a response ID is required.
+
         Args:
             survey_id: Survey for which to download files.
-            token: Optional participant token to filter uploaded files.
+            token: Participant token to filter uploaded files.
+            response_id: Response ID.
 
         Yields:
             :class:`~citric.types.ReadableFile` dictionaries.
@@ -1280,7 +1288,7 @@ class Client:  # noqa: PLR0904
            Yield :class:`~citric.types.ReadableFile` dictionaries instead of
            dataclass instances.
         """
-        files_data = self.get_uploaded_files(survey_id, token)
+        files_data = self.get_uploaded_files(survey_id, token, response_id)
         for file in files_data:
             yield {
                 "meta": files_data[file]["meta"],
@@ -1292,13 +1300,17 @@ class Client:  # noqa: PLR0904
         directory: str | Path,
         survey_id: int,
         token: str | None = None,
+        response_id: int | None = None,
     ) -> list[Path]:
         """Download files uploaded in survey response.
+
+        Either a token or a response ID is required.
 
         Args:
             directory: Where to store the files.
             survey_id: Survey for which to download files.
             token: Optional participant token to filter uploaded files.
+            response_id: Response ID.
 
         Returns:
             List with the paths of downloaded files.
@@ -1308,7 +1320,11 @@ class Client:  # noqa: PLR0904
         dirpath = Path(directory)
 
         filepaths = []
-        uploaded_files = self.get_uploaded_file_objects(survey_id, token=token)
+        uploaded_files = self.get_uploaded_file_objects(
+            survey_id,
+            token=token,
+            response_id=response_id,
+        )
 
         for file in uploaded_files:
             filepath = dirpath / file["meta"]["filename"]

--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -35,6 +35,8 @@ services:
       POSTGRES_USER: limesurvey
       POSTGRES_DB: limesurvey
       POSTGRES_PASSWORD: secret
+    ports:
+      - 5433:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "limesurvey"]
       interval: 15s

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -1278,6 +1278,11 @@ def test_response_files(
         assert files[1]["meta"]["name"] == result2["name"]
         assert files[1]["content"].read() == content2
 
+    def _assert_downloads(paths: list[Path]) -> None:
+        assert len(paths) == 2
+        assert paths[0].read_bytes() == content1
+        assert paths[1].read_bytes() == content2
+
     with subtests.test("by_token"):
         _assert_files(
             list(
@@ -1285,6 +1290,17 @@ def test_response_files(
                     survey_id,
                     token=token,
                 )
+            )
+        )
+
+        # Download files to a directory
+        download_dir = tmp_path / "downloads_by_token"
+        download_dir.mkdir(parents=True, exist_ok=True)
+        _assert_downloads(
+            client.download_files(
+                download_dir,
+                survey_id,
+                token=token,
             )
         )
 
@@ -1298,13 +1314,16 @@ def test_response_files(
             )
         )
 
-    # Download files to a directory
-    download_dir = tmp_path / "downloads"
-    download_dir.mkdir(parents=True, exist_ok=True)
-    paths = client.download_files(download_dir, survey_id, token)
-    assert len(paths) == 2
-    assert paths[0].read_bytes() == content1
-    assert paths[1].read_bytes() == content2
+        # Download files to a directory
+        download_dir = tmp_path / "downloads_by_response_id"
+        download_dir.mkdir(parents=True, exist_ok=True)
+        _assert_downloads(
+            client.download_files(
+                download_dir,
+                survey_id,
+                response_id=response_id,
+            )
+        )
 
 
 @pytest.mark.integration_test

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -32,9 +32,9 @@ from citric.exceptions import LimeSurveyApiError, LimeSurveyStatusError
 from citric.objects import Participant
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Iterable
 
-    from citric.types import QuestionsListElement, ReadableFile
+    from citric.types import FileUploadResult, QuestionsListElement, ReadableFile
     from tests.fixtures import MailpitClient
 
 NEW_SURVEY_NAME = "New Survey"
@@ -1213,8 +1213,36 @@ def file_upload_question(
     return question
 
 
+def assert_uploaded_files(  # noqa: D103
+    files: Iterable[tuple[ReadableFile, FileUploadResult, bytes]],
+    subtests: pytest.Subtests,
+) -> None:
+    for down, up, content in files:
+        with subtests.test(up["name"]):
+            assert down["meta"]["filename"] == up["filename"]
+            assert down["meta"]["size"] == up["size"]
+            assert down["meta"]["ext"] == up["ext"]
+            assert down["meta"]["name"] == up["name"]
+            assert down["content"].read() == content
+
+
+def assert_downloaded_files(  # noqa: D103
+    files: Iterable[tuple[Path, FileUploadResult, bytes]],
+    subtests: pytest.Subtests,
+) -> None:
+    for path, up, content in files:
+        with subtests.test(up["name"]):
+            assert path.read_bytes() == content
+
+
+@pytest.mark.parametrize(
+    "by_response_id",
+    [False, True],
+    ids=["by_token", "by_response_id"],
+)
 @pytest.mark.integration_test
-def test_response_files(
+def test_response_files(  # noqa: PLR0914
+    request: pytest.FixtureRequest,
     client: citric.Client,
     survey_id: int,
     file_upload_question: QuestionsListElement,
@@ -1222,8 +1250,21 @@ def test_response_files(
     faker: Faker,
     server_version: semver.VersionInfo,
     subtests: pytest.Subtests,
-):
+    by_response_id: bool,  # noqa: FBT001
+) -> None:
     """Test response files."""
+    if by_response_id:
+        request.applymarker(
+            pytest.mark.xfail(
+                server_version < (6, 0, 0),
+                reason=(
+                    "Getting uploaded files by response ID is not supported in "
+                    f"LimeSurvey {server_version} < 6.0.0"
+                ),
+                strict=True,
+            ),
+        )
+
     token = "T00000"
     fieldname = client._fieldname_from_question(file_upload_question)
 
@@ -1259,71 +1300,39 @@ def test_response_files(
 
     export = json.loads(client.export_responses(survey_id, token=token))
     assert len(export["responses"]) == 1
-    assert export["responses"][0]["id"] == response_id
+    assert int(export["responses"][0]["id"]) == response_id
     assert len(json.loads(export["responses"][0]["G02Q03"])) == 2
     assert int(export["responses"][0]["G02Q03[filecount]"]) == 2
 
-    def _assert_files(files: list[ReadableFile]) -> None:
-        assert len(files) == 2
+    download_dir = tmp_path / "downloads"
+    download_dir.mkdir(parents=True, exist_ok=True)
 
-        assert files[0]["meta"]["filename"] == result1["filename"]
-        assert files[0]["meta"]["size"] == result1["size"]
-        assert files[0]["meta"]["ext"] == result1["ext"]
-        assert files[0]["meta"]["name"] == result1["name"]
-        assert files[0]["content"].read() == content1
-
-        assert files[1]["meta"]["filename"] == result2["filename"]
-        assert files[1]["meta"]["size"] == result2["size"]
-        assert files[1]["meta"]["ext"] == result2["ext"]
-        assert files[1]["meta"]["name"] == result2["name"]
-        assert files[1]["content"].read() == content2
-
-    def _assert_downloads(paths: list[Path]) -> None:
-        assert len(paths) == 2
-        assert paths[0].read_bytes() == content1
-        assert paths[1].read_bytes() == content2
-
-    with subtests.test("by_token"):
-        _assert_files(
-            list(
-                client.get_uploaded_file_objects(
-                    survey_id,
-                    token=token,
-                )
-            )
+    if by_response_id:
+        get_file_objects = client.get_uploaded_file_objects(
+            survey_id,
+            response_id=response_id,
+        )
+        download_files = client.download_files(
+            download_dir,
+            survey_id,
+            response_id=response_id,
+        )
+    else:
+        get_file_objects = client.get_uploaded_file_objects(
+            survey_id,
+            token=token,
+        )
+        download_files = client.download_files(
+            download_dir,
+            survey_id,
+            token=token,
         )
 
-        # Download files to a directory
-        download_dir = tmp_path / "downloads_by_token"
-        download_dir.mkdir(parents=True, exist_ok=True)
-        _assert_downloads(
-            client.download_files(
-                download_dir,
-                survey_id,
-                token=token,
-            )
-        )
+    files = zip(get_file_objects, [result1, result2], [content1, content2], strict=True)
+    assert_uploaded_files(files, subtests)
 
-    with subtests.test("by_response_id"):
-        _assert_files(
-            list(
-                client.get_uploaded_file_objects(
-                    survey_id,
-                    response_id=response_id,
-                )
-            )
-        )
-
-        # Download files to a directory
-        download_dir = tmp_path / "downloads_by_response_id"
-        download_dir.mkdir(parents=True, exist_ok=True)
-        _assert_downloads(
-            client.download_files(
-                download_dir,
-                survey_id,
-                response_id=response_id,
-            )
-        )
+    paths = zip(download_files, [result1, result2], [content1, content2], strict=True)
+    assert_downloaded_files(paths, subtests)
 
 
 @pytest.mark.integration_test

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -34,7 +34,7 @@ from citric.objects import Participant
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-    from citric.types import QuestionsListElement
+    from citric.types import QuestionsListElement, ReadableFile
     from tests.fixtures import MailpitClient
 
 NEW_SURVEY_NAME = "New Survey"
@@ -1221,6 +1221,7 @@ def test_response_files(
     tmp_path: Path,
     faker: Faker,
     server_version: semver.VersionInfo,
+    subtests: pytest.Subtests,
 ):
     """Test response files."""
     token = "T00000"
@@ -1253,28 +1254,49 @@ def test_response_files(
             fieldname_filecount: len(response_files),
         },
     ]
-    assert client.add_responses(survey_id, responses) == [1]
+    response_id, *_ = client.add_responses(survey_id, responses)
+    assert response_id == 1
 
     export = json.loads(client.export_responses(survey_id, token=token))
     assert len(export["responses"]) == 1
+    assert export["responses"][0]["id"] == response_id
     assert len(json.loads(export["responses"][0]["G02Q03"])) == 2
     assert int(export["responses"][0]["G02Q03[filecount]"]) == 2
 
-    # Get uploaded files
-    files = list(client.get_uploaded_file_objects(survey_id, token))
-    assert len(files) == 2
+    def _assert_files(files: list[ReadableFile]) -> None:
+        assert len(files) == 2
 
-    assert files[0]["meta"]["filename"] == result1["filename"]
-    assert files[0]["meta"]["size"] == result1["size"]
-    assert files[0]["meta"]["ext"] == result1["ext"]
-    assert files[0]["meta"]["name"] == result1["name"]
-    assert files[0]["content"].read() == content1
+        assert files[0]["meta"]["filename"] == result1["filename"]
+        assert files[0]["meta"]["size"] == result1["size"]
+        assert files[0]["meta"]["ext"] == result1["ext"]
+        assert files[0]["meta"]["name"] == result1["name"]
+        assert files[0]["content"].read() == content1
 
-    assert files[1]["meta"]["filename"] == result2["filename"]
-    assert files[1]["meta"]["size"] == result2["size"]
-    assert files[1]["meta"]["ext"] == result2["ext"]
-    assert files[1]["meta"]["name"] == result2["name"]
-    assert files[1]["content"].read() == content2
+        assert files[1]["meta"]["filename"] == result2["filename"]
+        assert files[1]["meta"]["size"] == result2["size"]
+        assert files[1]["meta"]["ext"] == result2["ext"]
+        assert files[1]["meta"]["name"] == result2["name"]
+        assert files[1]["content"].read() == content2
+
+    with subtests.test("by_token"):
+        _assert_files(
+            list(
+                client.get_uploaded_file_objects(
+                    survey_id,
+                    token=token,
+                )
+            )
+        )
+
+    with subtests.test("by_response_id"):
+        _assert_files(
+            list(
+                client.get_uploaded_file_objects(
+                    survey_id,
+                    response_id=response_id,
+                )
+            )
+        )
 
     # Download files to a directory
     download_dir = tmp_path / "downloads"


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Adds a `response_id` keyword argument, to match the RPC method, to the following `Client` methods:

- `get_uploaded_files` - 1-1 with the RPC method
- `get_uploaded_file_objects` 
- `download_files`

## Related

- Closes https://github.com/edgarrmondragon/citric/issues/1777

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Add support for retrieving and downloading uploaded survey files by response ID in addition to token-based lookup.

New Features:
- Allow clients to fetch uploaded files for a survey response by response ID via get_uploaded_files.
- Allow clients to iterate over uploaded file objects filtered by response ID via get_uploaded_file_objects.
- Allow clients to download uploaded files filtered by response ID via download_files.

Tests:
- Expand integration tests for response file handling to cover both token-based and response-ID-based file retrieval using subtests.