### PR TITLE
chore: Fix Changie replacements config

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -50,7 +50,11 @@ replacements:
 - path: pyproject.toml
   find: "^version = \".*\"$"
   replace: "version = \"{{.VersionNoPrefix}}\""
-- path: src/citric/**/*.py
+# Go's filepath.Glob does not support **, so each subdirectory needs its own entry.
+- path: src/citric/*.py
+  find: "NEXT_VERSION"
+  replace: "{{.VersionNoPrefix}}"
+- path: src/citric/objects/*.py
   find: "NEXT_VERSION"
   replace: "{{.VersionNoPrefix}}"
 - path: .github/ISSUE_TEMPLATE/BUG.yml


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Go's `filepath.Glob` does not support `**`, so each subdirectory needs its own entry.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Enhancements:
- Replace unsupported recursive glob pattern with explicit subdirectory entries in Changie configuration for version replacement.