### PR TITLE
docs: Add missing "Added in version" admonitions

### DIFF
--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -51,7 +51,7 @@ _SEMVER_RE = re.compile(
 class ServerVersion:
     """A LimeSurvey server version.
 
-    .. versionadded:: NEXT_VERSION
+    .. versionadded:: 2.2.0
     """
 
     major: int
@@ -173,7 +173,7 @@ class Client:  # noqa: PLR0904
     def server_version(self) -> ServerVersion:
         """LimeSurvey server version (cached).
 
-        .. versionadded:: NEXT_VERSION
+        .. versionadded:: 2.2.0
         """
         if self.__server_version is None:
             self.__server_version = ServerVersion.parse(self.get_server_version())


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA, https://github.com/edgarrmondragon/citric/pull/1784 fixed this going forward.

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Documentation:
- Replace placeholder NEXT_VERSION tags with the specific 2.2.0 version in versionadded documentation for server version APIs.