### PR TITLE
ci: Use postgres:18-alpine

### DIFF
--- a/tests/compose.yaml
+++ b/tests/compose.yaml
@@ -30,7 +30,7 @@ services:
       start_period: 5s
 
   db:
-    image: postgres:18
+    image: postgres:18-alpine
     environment:
       POSTGRES_USER: limesurvey
       POSTGRES_DB: limesurvey


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Tests:
- Switch the test Docker Compose Postgres service to the lightweight postgres:18-alpine image.