### PR TITLE
ci: Measure tests coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,4 +333,5 @@ parallel = true
 relative_files = true
 source = [
   "citric",
+  "tests",
 ]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -49,7 +49,6 @@ class LimeSurveyMockAdapter(BaseAdapter):
 
     session_key = "123456"
     status_ok: ClassVar[dict[str, Any]] = {"status": "OK"}
-    rpc_interface = "json"
 
     ldap_session_key = "ldap-key"
 
@@ -81,8 +80,6 @@ class LimeSurveyMockAdapter(BaseAdapter):
             output["result"] = (
                 self.ldap_session_key if params[2] == "AuthLDAP" else self.session_key
             )
-        elif method == "get_site_settings" and params[1] == "RPCInterface":
-            output["result"] = self.rpc_interface
 
         response._content = json.dumps(output).encode()
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -39,14 +39,6 @@ class RPCOffAdapter(LimeSurveyMockAdapter):
     rpc_interface = "off"
 
 
-@pytest.fixture(scope="session")
-def off_session(url: str) -> requests.Session:
-    """Session with interface turned off."""
-    requests_session = requests.Session()
-    requests_session.mount(url, RPCOffAdapter())
-    return requests_session
-
-
 def test_method():
     """Test method magic."""
     m1 = Method(lambda x, *args: f"{x}({','.join(args)})", "hello")


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://nedbatchelder.com/blog/201908/dont_omit_tests_from_coverage
- https://nedbatchelder.com/blog/201106/running_coverage_on_your_tests

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Enable measuring coverage for the test suite and simplify related test fixtures.

Build:
- Configure coverage to include the tests package as part of measured source files.

Tests:
- Remove unused RPC interface test fixtures and helper session setup from the test suite.