### PR TITLE
chore: Revert "native support for uv in ReadTheDocs (#1776)"

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,15 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
-
-python:
-  install:
-    - method: uv
-      command: pip
-      requirements: requirements/docs.requirements.txt
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv pip install -r requirements/docs.requirements.txt
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv pip install .
 
 sphinx:
   builder: html


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

https://github.com/readthedocs/readthedocs.org/issues/13168

## Checklist

- [ ] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Build:
- Adjust Read the Docs configuration to install uv via asdf, create the virtualenv with uv, and install documentation dependencies and the project into that environment.