### PR TITLE
chore: Use native support for uv in ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,15 +7,12 @@ build:
   jobs:
     post_checkout:
       - git fetch --unshallow || true
-    pre_create_environment:
-      - asdf plugin add uv
-      - asdf install uv latest
-      - asdf global uv latest
-    create_environment:
-      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-    install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv pip install -r requirements/docs.requirements.txt
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv pip install .
+
+python:
+  install:
+    - method: uv
+      command: pip
+      requirements: requirements/docs.requirements.txt
 
 sphinx:
   builder: html


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

- https://github.com/readthedocs/readthedocs.org/issues/13168#issuecomment-4922705716
- https://github.com/edgarrmondragon/citric/pull/1776
- https://github.com/edgarrmondragon/citric/pull/1803

## Checklist

- [ ] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Switch ReadTheDocs configuration to use native uv integration for building documentation.

Enhancements:
- Simplify ReadTheDocs build configuration by relying on the built-in uv Python environment support instead of custom asdf-based setup.

Build:
- Update .readthedocs.yaml to configure Python installation via uv with pip using the docs requirements file.