### PR TITLE
fix: Allow creating surveys with no (None) survey ID so LimeSurvey can assign one automatically

### DIFF
--- a/.changes/unreleased/Fixed-20260720-094948.yaml
+++ b/.changes/unreleased/Fixed-20260720-094948.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Allow to set nullish id on survey creation
+time: 2026-07-20T09:49:48.687666828+02:00
+custom:
+    Issue: "1808"

--- a/.changes/unreleased/Fixed-20260720-094948.yaml
+++ b/.changes/unreleased/Fixed-20260720-094948.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Allow to set nullish id on survey creation
+body: Allow creating surveys with no (None) survey ID so LimeSurvey can assign one automatically
 time: 2026-07-20T09:49:48.687666828+02:00
 custom:
     Issue: "1808"

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -10,7 +10,7 @@ You can contribute in many ways.
 ### Report bugs or request features
 
 Report bugs and request new features in the repo [issue tracker][new-issue].
-The issue forms will guide to include all necessary information, like package version,
+The issue forms will guide you to include all necessary information, like package version,
 Python version, operating system, and so on.
 
 ### Fix bugs or implement features

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -10,7 +10,7 @@ You can contribute in many ways.
 ### Report bugs or request features
 
 Report bugs and request new features in the repo [issue tracker][new-issue].
-The issueforms will guide to include all necessary information, like package version,
+The issue forms will guide to include all necessary information, like package version,
 Python version, operating system, and so on.
 
 ### Fix bugs or implement features

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -344,7 +344,7 @@ class Client:  # noqa: PLR0904
 
     def add_survey(
         self,
-        survey_id: int,
+        survey_id: int | None,
         title: str,
         language: str,
         survey_format: str | enums.NewSurveyType = "G",
@@ -354,7 +354,8 @@ class Client:  # noqa: PLR0904
         Calls :rpc_method:`add_survey`.
 
         Args:
-            survey_id: The desired ID of the Survey to add.
+            survey_id: The desired ID of the Survey to add. If None, LimeSurvey will
+                automatically set a random ID on creation.
             title: Title of the new Survey.
             language: Default language of the Survey.
             survey_format: Question appearance format (A, G or S) for "All on one page",


### PR DESCRIPTION
## Summary

Allow to set a nullish id on survey creation and let LimeSurvey generate the new survey id.

Closes #1808

## Checklist

- [X] I have read the [CONTRIBUTING] guide.
- [X] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Allow surveys to be created without specifying an ID, letting LimeSurvey assign one automatically, and update contributing docs and changelog accordingly.

New Features:
- Support creating surveys with a null survey ID so LimeSurvey can auto-generate the identifier.

Bug Fixes:
- Fix inability to create surveys when no explicit survey ID is provided, deferring ID assignment to LimeSurvey.

Enhancements:
- Clarify the add_survey parameter documentation for survey_id behavior when omitted or None.
- Improve contributing guide wording around using GitHub issue forms.

Documentation:
- Document the ability to omit survey IDs on survey creation in the public client API documentation.

Chores:
- Add a changelog entry describing the fix for auto-assigned survey IDs.