### PR TITLE
feat: Added a export_responses_dict method to get responses represented as Python dictionaries

### DIFF
--- a/.changes/unreleased/Added-20260724-110231.yaml
+++ b/.changes/unreleased/Added-20260724-110231.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Added a `export_responses_dict` method to get responses represented as Python dictionaries
+time: 2026-07-24T11:02:31.526613824+02:00
+custom:
+  Issue: '1810'

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import datetime
 import io
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -705,7 +706,7 @@ class Client:  # noqa: PLR0904
         Calls :rpc_method:`export_responses`.
 
         Args:
-            survey_id: Survey to add the response to.
+            survey_id: Survey from which responses should be exported.
             token: Optional participant token to get responses for.
             file_format: Type of export. One of PDF, CSV, XLS, DOC or JSON.
             language: Export responses made to this language version of the survey.
@@ -760,6 +761,66 @@ class Client:  # noqa: PLR0904
             ),
         )
 
+    def export_responses_dict(
+        self,
+        survey_id: int,
+        *,
+        token: str | None = None,
+        language: str | None = None,
+        completion_status: str | enums.SurveyCompletionStatus = "all",
+        heading_type: str | enums.HeadingType = "code",
+        response_type: str | enums.ResponseType = "short",
+        from_response_id: int | None = None,
+        to_response_id: int | None = None,
+        fields: Sequence[str] | None = None,
+        additional_options: types.ExportAdditionalOptions | None = None,
+    ) -> list[dict[str, Any]]:
+        """Export responses represented as dictionaries.
+
+        Calls :rpc_method:`export_responses`.
+
+        Args:
+            survey_id: Survey from which responses should be exported.
+            token: Optional participant token to get responses for.
+            language: Export responses made to this language version of the survey.
+            completion_status: Incomplete, complete or all.
+            heading_type: Use response codes, long or abbreviated titles.
+            response_type: Export long or short text responses.
+            from_response_id: First response to export.
+            to_response_id: Last response to export.
+            fields: Which response fields to export. If none, exports all fields.
+            additional_options: Dictionary of additional options to format the export.
+
+        Returns:
+            A list of responses represented as dictionaries
+
+
+        Raises:
+            ValueError: If the received JSON has not the expected structure
+
+        .. versionadded:: 2.2.2
+        """
+        dict_responses: dict[str, Any] = json.loads(
+            self.export_responses(
+                survey_id,
+                token=token,
+                language=language,
+                completion_status=completion_status,
+                heading_type=heading_type,
+                response_type=response_type,
+                from_response_id=from_response_id,
+                to_response_id=to_response_id,
+                fields=fields,
+                additional_options=additional_options,
+            )
+        )
+
+        if "responses" not in dict_responses:
+            msg = "The received JSON has not the expected structure."
+            raise ValueError(msg)
+
+        return dict_responses["responses"]
+
     def save_responses(  # noqa: PLR0913
         self,
         filename: PathLike[str],
@@ -780,7 +841,7 @@ class Client:  # noqa: PLR0904
 
         Args:
             filename: Target file path.
-            survey_id: Survey to add the response to.
+            survey_id: Survey from which responses should be exported.
             token: Optional participant token to get responses for.
             file_format: Type of export. One of PDF, CSV, XLS, DOC or JSON.
             language: Export responses made to this language version of the survey.

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -16,6 +16,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 from urllib.parse import quote
 
 import bs4
@@ -872,7 +873,7 @@ def responses() -> list[dict]:
 
 
 @pytest.mark.integration_test
-def test_responses(
+def test_responses(  # ruff:ignore[too-many-statements]
     client: citric.Client,
     server_version: semver.VersionInfo,
     survey_id: int,
@@ -950,6 +951,20 @@ def test_responses(
         for i, response in enumerate(json_data["responses"]):
             int_value = 1 if responses[i]["G02Q04"] == "Y" else 0
             assert response["G02Q04"] == int_value
+
+    # Export responses as dictionaries
+    with subtests.test(msg="Export responses as dictionaries"):
+        dict_responses = client.export_responses_dict(survey_id)
+
+        assert len(dict_responses) == 3
+
+        with (
+            patch.object(client, "export_responses", return_value='{"test": []}'),
+            pytest.raises(
+                ValueError, match=r"The received JSON has not the expected structure\."
+            ),
+        ):
+            client.export_responses_dict(survey_id)
 
     # Save responses to a file
     filepath = tmp_path / "responses.json"


### PR DESCRIPTION
## Summary

Added a export_responses_dict method to get responses represented as Python dictionaries. Closes #1810 

## Checklist

- [X] I have read the [CONTRIBUTING] guide.
- [X] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Add support for exporting survey responses as Python dictionaries and align linting directives and tests with current tooling.

New Features:
- Introduce Client.export_responses_dict to retrieve survey responses as a list of Python dictionaries.

Enhancements:
- Update linting suppression comments from flake8/noqa style to ruff-specific directives across client and integration tests.

Documentation:
- Add a changelog entry documenting the new export_responses_dict method.

Tests:
- Extend integration tests to cover exporting responses via export_responses_dict and verify the expected number of responses.