### PR TITLE
ci: Run fewer CI jobs in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           no_output_timeout: 5m
       - run:
           name: Run unit tests
-          command: uvx nox -s lowest test
+          command: uvx nox --no-error-on-missing-interpreters -s lowest-requirements test
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,49 +55,42 @@ env:
 
 jobs:
   tests:
-    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }} (dependencies: ${{ matrix.session || 'highest' }})"
+    name: "Python ${{ join(matrix.python-version, ', ') }} / ${{ matrix.os }} (${{ matrix.session || 'unit' }})"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
       COVERAGE_FILE: ".coverage.unit"
-      NOXFORCEPYTHON: "${{ matrix.python-version }}"
     strategy:
       fail-fast: false
       matrix:
         include:
-        - python-version: "3.10"
+        - python-version: ["3.10"]
           os: ubuntu-24.04
-          session: lowest
+          session: lowest-requirements
 
-        - python-version: "3.14"
+        - python-version: ["3.10", "3.14"]
           os: ubuntu-24.04
+          session: xdoctest
 
-        - python-version: "3.14t"
-          os: ubuntu-24.04
-
-        - python-version: "3.13"
-          os: ubuntu-24.04
-
-        - python-version: "3.12"
-          os: ubuntu-24.04
-
-        - python-version: "3.11"
-          os: ubuntu-24.04
-
-        - python-version: "3.10"
+        - python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "3.15"
+          - "3.15t"
           os: ubuntu-24.04
 
-        - python-version: "3.15"
+        - python-version: ["3.16"]
           os: ubuntu-24.04
 
-        - python-version: "3.15t"
-          os: ubuntu-24.04
-
-        - python-version: "3.14"
+        - python-version: ["3.14"]
           os: windows-2025
 
-        - python-version: "3.14"
+        - python-version: ["3.14"]
           os: macos-26
 
     steps:
@@ -106,12 +99,19 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Setup Python ${{ matrix.python-version }}
+    - name: Setup Python
+      if: ${{ matrix.python-version[0] != '3.16' }}
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ join(matrix.python-version, fromJson('"\n"')) }}
         architecture: x64
         allow-prereleases: true
+
+    - name: Setup pre-release Python
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
+      if: matrix.python-version[0] == '3.16'
+      with:
+        python-version: ${{ format('{0}-dev', matrix.python-version[0]) }}
 
     - name: Install tools
       uses: ./.github/actions/install-tools
@@ -122,6 +122,8 @@ jobs:
 
     - name: Run Tests
       env:
+        NOX_DOWNLOAD_PYTHON: never
+        NOXFORCEPYTHON: ${{ join(matrix.python-version, ',') }}
         NOXSESSION: ${{ matrix.session || 'test' }}
       run: |
         nox --verbose -- --junit-xml=tests.xml
@@ -130,7 +132,7 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         include-hidden-files: true
-        name: "coverage-unit-${{ matrix.os }}-${{ matrix.python-version }}"
+        name: "coverage-unit-${{ matrix.os }}-${{ join(matrix.python-version, '-') }}"
         path: ".coverage.*"
 
     - name: Upload test results to Codecov
@@ -139,12 +141,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: tests.xml
-        flags: unit-${{ matrix.os }}-${{ matrix.python-version }}
+        flags: unit-${{ matrix.os }}-${{ join(matrix.python-version, '-') }}
         report_type: test_results
-
-    - name: Run Doctests
-      run: |
-        nox -s xdoctest
 
   lint:
     name: Lint

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,7 +118,7 @@ def xdoctest(session: nox.Session) -> None:
     session.run("python", "-m", "xdoctest", *args)
 
 
-@nox.session(python=python_versions[0], tags=["test"])
+@nox.session(name="lowest-requirements", python=python_versions[0], tags=["test"])
 def lowest(session: nox.Session) -> None:
     """Execute pytest tests on the lowest supported Python."""
     env = {"COVERAGE_CORE": "sysmon"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3.15",
+  "Programming Language :: Python :: 3.16",
   "Programming Language :: Python :: Free Threading :: 4 - Resilient",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
@@ -250,7 +251,7 @@ DEP004 = [
 ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.15"
+max_supported_python = "3.16"
 table_format = "long"
 
 [tool.typos]

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -195,7 +195,7 @@ def test_survey(
 
     # Add a new survey
     survey_id = client.add_survey(
-        5555,
+        None,
         NEW_SURVEY_NAME,
         "es",
         enums.NewSurveyType.GROUP_BY_GROUP,
@@ -282,7 +282,7 @@ def test_copy_survey_destination_id(client: citric.Client, survey_id: int):
 def test_group(client: citric.Client, server_version: semver.Version):
     """Test group methods."""
     # Create a new survey
-    survey_id = client.add_survey(1234, "New Survey", "en")
+    survey_id = client.add_survey(None, "New Survey", "en")
 
     # Import a group
     with Path("./examples/group.lsg").open("rb") as f:


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist

- [ ] I have read the [CONTRIBUTING] guide.
- [ ] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Reduce CI parallelism by consolidating Python version jobs, adding support for Python 3.16, and aligning test sessions and configuration with the updated environment matrix.

New Features:
- Declare support for Python 3.16 in project metadata and formatting configuration.

Bug Fixes:
- Adjust integration tests to create surveys without explicit IDs to match current client behavior.

Enhancements:
- Restructure GitHub Actions test matrix to run multiple Python versions per job, including special handling for pre-release 3.16 builds.
- Update Nox session naming from `lowest` to `lowest-requirements` and propagate this change to CI configurations.
- Ensure NOX environment variables reflect the new multi-version test matrix and improve coverage and Codecov artifact naming.

CI:
- Update CircleCI configuration to run the renamed `lowest-requirements` test session instead of the old `lowest` session.

Tests:
- Remove separate doctest step from the GitHub Actions workflow in favor of handling doctests via Nox sessions.