### PR TITLE
refactor: Use lazy imports on Python 3.15

### DIFF
--- a/.changes/unreleased/Refactored-20260731-145702.yaml
+++ b/.changes/unreleased/Refactored-20260731-145702.yaml
@@ -1,0 +1,5 @@
+kind: Refactored
+body: Use lazy imports on Python 3.15
+time: 2026-07-31T14:57:02.609523-06:00
+custom:
+    Issue: "1816"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ test = [
   "python-dotenv>=1",
   "semver>=3.0.1",
   "tinydb>=4.8",
+  "tomli>=2.3",
   "xdoctest[colors]>=1.1.1",
 ]
 docs = [

--- a/src/citric/__init__.py
+++ b/src/citric/__init__.py
@@ -2,6 +2,11 @@
 
 """A client to the LimeSurvey Remote Control API 2, written in modern Python."""
 
+__lazy_modules__ = {
+    "citric.client",
+    "citric.rest",
+}
+
 from citric import objects
 from citric.client import Client, ServerVersion
 from citric.rest import RESTClient

--- a/src/citric/client.py
+++ b/src/citric/client.py
@@ -4,6 +4,17 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "base64",
+    "citric.exceptions",
+    "citric.session",
+    "datetime",
+    "io",
+    "json",
+    "pathlib",
+    "requests",
+}
+
 import base64
 import datetime
 import io

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -4,6 +4,10 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "typing",
+}
+
 import enum
 import sys
 from typing import Type  # ruff: ignore[deprecated-import]

--- a/src/citric/objects/__init__.py
+++ b/src/citric/objects/__init__.py
@@ -2,6 +2,11 @@
 
 """Python classes associated with LimeSurvey objects (surveys, questions, etc.)."""
 
+__lazy_modules__ = {
+    "citric.objects._participant",
+    "citric.objects._question",
+}
+
 from ._participant import Participant, to_yes_no
 from ._question import AnswerOption, Question, QuestionL10n
 

--- a/src/citric/objects/_question.py
+++ b/src/citric/objects/_question.py
@@ -4,6 +4,13 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "io",
+    "xml",
+    "xml.etree",
+    "xml.etree.ElementTree",
+}
+
 import io
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
 from dataclasses import dataclass, field

--- a/src/citric/rest.py
+++ b/src/citric/rest.py
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "importlib",
+    "requests",
+}
+
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, Type  # ruff: ignore[deprecated-import]
 

--- a/src/citric/session.py
+++ b/src/citric/session.py
@@ -4,6 +4,15 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "citric.exceptions",
+    "citric.method",
+    "importlib",
+    "json",
+    "random",
+    "requests",
+}
+
 import json
 import logging
 import random

--- a/src/citric/types.py
+++ b/src/citric/types.py
@@ -4,6 +4,11 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "io",
+    "typing_extensions",
+}
+
 import io
 import sys
 from typing import Any, Literal, TypeAlias, TypedDict


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

SSIA.

```
venv -p 3.15 --clear
uv pip install --python .venv/bin/python -e .
.venv/bin/python -X importtime -c 'import citric' 2> import.log
uvx tuna import.log
```

- https://docs.python.org/3.15/whatsnew/3.15.html#whatsnew315-lazy-imports

### Before

<img width="734" height="727" alt="import-before" src="https://github.com/user-attachments/assets/c07c952c-0491-4473-b900-7de20d2c3a08" />

### After

<img width="675" height="272" alt="import" src="https://github.com/user-attachments/assets/5d6dbf54-a9bf-47dd-9f88-7b6fbea9ed6c" />

## Checklist

- [x] I have read the [CONTRIBUTING] guide.
- [x] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Adopt Python 3.15 lazy-import support across core citric modules to reduce upfront import overhead.

Enhancements:
- Declare __lazy_modules__ sets in core runtime modules (client, session, enums, types, REST, objects) to enable Python 3.15 lazy imports and improve startup performance.

Documentation:
- Add a changelog entry documenting the switch to lazy imports on Python 3.15.

## Summary by Sourcery

Adopt Python 3.15 lazy-import support to reduce citric’s upfront import overhead.

Enhancements:
- Declare __lazy_modules__ in core modules (client, session, enums, types, REST, objects, package __init__) to enable Python 3.15 lazy imports and improve startup performance.

Build:
- Add tomli as a test dependency in pyproject.toml.

Documentation:
- Add a changelog entry documenting the switch to lazy imports on Python 3.15.