### PR TITLE
feat: Add QuestionType enum and use it in Question.type

### DIFF
--- a/.changes/unreleased/Added-20260808-164327.yaml
+++ b/.changes/unreleased/Added-20260808-164327.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added a question type enum
+time: 2026-08-08T16:43:27.224483+02:00

--- a/.changes/unreleased/Added-20260808-164327.yaml
+++ b/.changes/unreleased/Added-20260808-164327.yaml
@@ -1,3 +1,5 @@
 kind: Added
 body: Added a question type enum
 time: 2026-08-08T16:43:27.224483+02:00
+custom:
+    Issue: "1820"

--- a/code_samples/import_question.py
+++ b/code_samples/import_question.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 # start example
 from citric import Client
+from citric.enums import QuestionType
 from citric.objects import AnswerOption, Question, QuestionL10n
 
 LS_URL = "http://localhost:8001/index.php/admin/remotecontrol"
@@ -18,7 +19,7 @@ group_id = client.list_groups(survey_id)[0]["id"]
 # A simple single-choice (list) question with answer options
 list_question = Question(
     title="Q01",
-    type="L",
+    type=QuestionType.RADIO_BUTTONS_LIST,
     l10ns={
         "en": QuestionL10n(question="What is your favourite colour?"),
         "es": QuestionL10n(question="Cual es tu color favorito?"),
@@ -35,22 +36,22 @@ client.import_question(list_question.to_lsq(), survey_id, group_id)
 # A multiple-choice question with subquestions
 mc_question = Question(
     title="Q02",
-    type="M",
+    type=QuestionType.CHECKBOXES_MULTIPLE_CHOICE,
     l10ns={"en": QuestionL10n(question="Which of the following do you use?")},
     subquestions=[
         Question(
             title="SQ001",
-            type="T",
+            type=QuestionType.LONG_FREE_TEXT,
             l10ns={"en": QuestionL10n(question="Python")},
         ),
         Question(
             title="SQ002",
-            type="T",
+            type=QuestionType.LONG_FREE_TEXT,
             l10ns={"en": QuestionL10n(question="R")},
         ),
         Question(
             title="SQ003",
-            type="T",
+            type=QuestionType.LONG_FREE_TEXT,
             l10ns={"en": QuestionL10n(question="Julia")},
         ),
     ],

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -23,6 +23,7 @@ __all__ = [
     "ImportGroupType",
     "ImportSurveyType",
     "NewSurveyType",
+    "QuestionType",
     "QuotaAction",
     "ResponseType",
     "ResponsesExportFormat",
@@ -163,3 +164,37 @@ class UserStatus(enum.IntEnum):
 
     ACTIVATED = 1
     DEACTIVATED = 0
+
+
+class QuestionType(StrEnum):
+    """Question type."""
+
+    ARRAY_DUAL = "1"
+    POINT_CHOICE = "5"
+    ARRAY_5_POINT = "A"
+    ARRAY_10_POINT = "B"
+    ARRAY_YES_UNCERTAIN_NO = "C"
+    DATE = "D"
+    ARRAY_INC_SAME_DEC = "E"
+    ARRAY = "F"
+    GENDER = "G"
+    ARRAY_COLUMN = "H"
+    LANGUAGE = "I"
+    MULTIPLE_NUMERICAL = "K"
+    RADIO_BUTTONS_LIST = "L"
+    CHECKBOXES_MULTIPLE_CHOICE = "M"
+    NUMERICAL = "N"
+    LIST_WITH_COMMENT = "O"
+    MULTIPLE_CHOICE_WITH_COMMENTS = "P"
+    MULTIPLE_SHORT_TEXT = "Q"
+    RANKING = "R"
+    SHORT_FREE_TEXT = "S"
+    LONG_FREE_TEXT = "T"
+    HUGE_FREE_TEXT = "U"
+    TEXT_DISPLAY = "X"
+    YES_NO_RADIO = "Y"
+    LIST_DROPDOWN = "!"
+    FILE_UPLOAD = "|"
+    EQUATION = "*"
+    ARRAY_NUMBERS = ":"
+    ARRAY_TEXT = ";"

--- a/src/citric/enums.py
+++ b/src/citric/enums.py
@@ -167,7 +167,12 @@ class UserStatus(enum.IntEnum):
 
 
 class QuestionType(StrEnum):
-    """Question type."""
+    """Question type as defined in LimeSurvey.
+
+    See https://github.com/LimeSurvey/LimeSurvey/blob/master/application/models/QuestionType.php
+
+    Some constant names have been updated for better comprehension.
+    """
 
     ARRAY_DUAL = "1"
     POINT_CHOICE = "5"

--- a/src/citric/objects/_question.py
+++ b/src/citric/objects/_question.py
@@ -14,6 +14,10 @@ __lazy_modules__ = {
 import io
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from citric import enums
 
 
 def _add_fields(parent: ET.Element, field_names: list[str]) -> None:
@@ -104,12 +108,14 @@ class Question:
     """
 
     title: str
-    type: str
+    type: enums.QuestionType | str
     l10ns: dict[str, QuestionL10n]
     mandatory: bool = False
     other: bool = False
     encrypted: bool = False
     relevance: str = "1"
+    """The condition when the question is displayed or not"""
+
     scale_id: int = 0
     preg: str | None = None
     attributes: dict[str, str] = field(default_factory=dict)

--- a/tests/integration/test_rpc_client.py
+++ b/tests/integration/test_rpc_client.py
@@ -100,7 +100,7 @@ def question_with_free_text(faker: Faker) -> citric.objects.Question:
     """Create a question of free-text (T) type."""
     return citric.objects.Question(
         title=faker.lexify("Q??????", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
-        type="T",
+        type=enums.QuestionType.LONG_FREE_TEXT,
         l10ns={
             "en": citric.objects.QuestionL10n(question=faker.sentence()),
             "es": citric.objects.QuestionL10n(question=Faker("es").sentence()),
@@ -471,12 +471,12 @@ def test_import_question_with_subquestions(
     sq_texts = [faker.sentence() for _ in sq_titles]
     q = citric.objects.Question(
         title=faker.lexify("M??????", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
-        type="M",
+        type=enums.QuestionType.CHECKBOXES_MULTIPLE_CHOICE,
         l10ns={"en": citric.objects.QuestionL10n(question=faker.sentence())},
         subquestions=[
             citric.objects.Question(
                 title=title,
-                type="T",
+                type=enums.QuestionType.LONG_FREE_TEXT,
                 l10ns={"en": citric.objects.QuestionL10n(question=text)},
             )
             for title, text in zip(sq_titles, sq_texts, strict=True)
@@ -523,7 +523,7 @@ def test_import_question_answer_options(
 
     q = citric.objects.Question(
         title=faker.lexify("L??????", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
-        type="L",
+        type=enums.QuestionType.RADIO_BUTTONS_LIST,
         l10ns={
             "en": citric.objects.QuestionL10n(question="What's your favourite colour?"),
             "es": citric.objects.QuestionL10n(question="¿Cuál es tu color favorito?"),
@@ -565,7 +565,7 @@ def test_import_question_with_attributes(
     css_class = faker.lexify("cls_??????", letters=string.ascii_lowercase)
     q = citric.objects.Question(
         title=faker.lexify("Q??????", letters="ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
-        type="T",
+        type=enums.QuestionType.LONG_FREE_TEXT,
         l10ns={"en": citric.objects.QuestionL10n(question=faker.sentence())},
         attributes={"cssclass": css_class},
     )

--- a/tests/objects/test_question.py
+++ b/tests/objects/test_question.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
 
+from citric.enums import QuestionType
 from citric.objects import AnswerOption, Question, QuestionL10n
 
 
@@ -17,7 +18,7 @@ def test_document_metadata():
     """Test that the document root has the correct metadata."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
     )
     root = _parse(q)
@@ -32,7 +33,7 @@ def test_custom_db_version():
     """Test that the db_version parameter is reflected in the XML output."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
     )
     root = ET.parse(q.to_lsq(db_version=999)).getroot()  # ruff: ignore[suspicious-xml-element-tree-usage]
@@ -43,7 +44,7 @@ def test_simple_text_question():
     """Test a simple text question with no subquestions or answer options."""
     q = Question(
         title="G01Q01",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="What is your name?")},
     )
     root = _parse(q)
@@ -74,7 +75,7 @@ def test_empty_attributes_omits_section():
     """Test that an empty attributes dict omits the question_attributes section."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
         attributes={},
     )
@@ -85,7 +86,7 @@ def test_list_question_with_answer_options():
     """Test a list question with answer options and a question attribute."""
     q = Question(
         title="Q1",
-        type="L",
+        type=QuestionType.RADIO_BUTTONS_LIST,
         l10ns={"en": QuestionL10n(question="Pick one")},
         attributes={"answer_order": "random"},
         answer_options=[
@@ -122,17 +123,17 @@ def test_multiple_choice_with_subquestions():
     """Test a multiple-choice question with two subquestions."""
     q = Question(
         title="Q1",
-        type="M",
+        type=QuestionType.CHECKBOXES_MULTIPLE_CHOICE,
         l10ns={"en": QuestionL10n(question="Which apply?")},
         subquestions=[
             Question(
                 title="SQ001",
-                type="T",
+                type=QuestionType.LONG_FREE_TEXT,
                 l10ns={"en": QuestionL10n(question="Option A")},
             ),
             Question(
                 title="SQ002",
-                type="T",
+                type=QuestionType.LONG_FREE_TEXT,
                 l10ns={"en": QuestionL10n(question="Option B")},
             ),
         ],
@@ -171,7 +172,7 @@ def test_html_content_entities():
     html = "Text with <strong>bold</strong> & 'quotes'"
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question=html)},
     )
     root = _parse(q)
@@ -184,7 +185,7 @@ def test_mandatory_question():
     """Test that mandatory=True produces 'Y' in the XML output."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Required")},
         mandatory=True,
     )
@@ -198,7 +199,7 @@ def test_xml_declaration():
     """Test that the output contains an XML declaration with UTF-8 encoding."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
     )
     content = q.to_lsq().read()
@@ -210,7 +211,7 @@ def test_fields_element_present():
     """Test that the questions section contains a fields element with expected names."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
     )
     root = _parse(q)
@@ -225,7 +226,7 @@ def test_multilanguage():
     """Test that multiple languages produce correct rows in questions and l10ns."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={
             "en": QuestionL10n(question="Hello"),
             "de": QuestionL10n(question="Hallo"),
@@ -245,7 +246,7 @@ def test_preg_empty_is_self_closing():
     """Test that a None preg field produces a self-closing element."""
     q = Question(
         title="Q1",
-        type="T",
+        type=QuestionType.LONG_FREE_TEXT,
         l10ns={"en": QuestionL10n(question="Hello")},
         preg=None,
     )
@@ -261,7 +262,7 @@ def test_answer_aid_sequential():
     """Test that answer_l10ns rows reference sequential aid values."""
     q = Question(
         title="Q1",
-        type="L",
+        type=QuestionType.RADIO_BUTTONS_LIST,
         l10ns={"en": QuestionL10n(question="Pick one")},
         answer_options=[
             AnswerOption(code="A1", l10ns={"en": "Yes"}),


### PR DESCRIPTION
## Summary

Added a question type enum for easier question creation. Added docstrings to some question attributes.

## Checklist

- [X] I have read the [CONTRIBUTING] guide.
- [X] For user-facing changes, refactorings, performance improvements or documentation updates, I have added a changelog entry using [Changie].

[changie]: https://changie.dev/
[contributing]: https://citric.readthedocs.io/en/latest/contributing/code-of-conduct.html

## Summary by Sourcery

Introduce a dedicated enum for question types and integrate it into the question model.

New Features:
- Add a QuestionType enum representing supported question type codes.

Enhancements:
- Update Question.type to accept the new QuestionType enum in addition to raw strings.
- Add docstrings clarifying question attributes such as relevance.

Documentation:
- Add a changelog entry describing the new QuestionType enum.